### PR TITLE
fix: remove unused function call

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -4,7 +4,7 @@ import { sendEventToDiscordSubscribers } from './discord';
 import { sendPushNotification } from './helpers/beams';
 import db from './helpers/mysql';
 import { sha256 } from './helpers/utils';
-import { getProposal, getProposalScores } from './helpers/proposal';
+import { getProposal } from './helpers/proposal';
 
 const delay = 5;
 const interval = 15;
@@ -105,14 +105,6 @@ async function processEvents(subscribers) {
 
   for (const event of events) {
     const proposalId = event.id.replace('proposal/', '');
-    if (event.event === 'proposal/end') {
-      try {
-        const scores = await getProposalScores(proposalId);
-        console.log('[events] Stored scores on proposal/end', proposalId, scores);
-      } catch (e) {
-        console.log('[events] getProposalScores failed:', e);
-      }
-    }
 
     // Send event to discord subscribers and webhook subscribers and then delete event from db
     // TODO: handle errors and retry

--- a/src/helpers/proposal.ts
+++ b/src/helpers/proposal.ts
@@ -33,10 +33,6 @@ export async function getProposal(id) {
   return proposal;
 }
 
-export async function getProposalScores(proposalId) {
-  return snapshot.utils.getJSON(`${hubURL}/api/scores/${proposalId}`);
-}
-
 export async function checkSpace(space) {
   try {
     const spaceData = await snapshot.utils.getJSON(`${hubURL}/api/spaces/${space}`);


### PR DESCRIPTION
# Issues 

The call to `getProposalScores` does not do anything, beside outputting the value to `console.log`. I guess it's something left behind by a previous refactoring.

# Changes 

Remove the call to this function as well as removing the function itself, which save a call to an external service.