### PR TITLE
fix: add timeout on outgoing webhook requests

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -1,4 +1,4 @@
-import fetch from 'cross-fetch';
+import fetch from 'node-fetch';
 import snapshot from '@snapshot-labs/snapshot.js';
 import { sendEventToDiscordSubscribers } from './discord';
 import { sendPushNotification } from './helpers/beams';
@@ -9,6 +9,7 @@ import { capture } from './helpers/sentry';
 
 const delay = 5;
 const interval = 15;
+const HTTP_WEBHOOK_TIMEOUT = 15000;
 const serviceEvents = parseInt(process.env.SERVICE_EVENTS || '0');
 const serviceEventsSalt = parseInt(process.env.SERVICE_EVENTS_SALT || '12345');
 const servicePushNotifications = parseInt(process.env.SERVICE_PUSH_NOTIFICATIONS || '0');
@@ -79,12 +80,18 @@ export async function sendEvent(event, to) {
         'Content-Type': 'application/json',
         Authentication: headerSecret
       },
-      body: JSON.stringify(event)
+      body: JSON.stringify(event),
+      timeout: HTTP_WEBHOOK_TIMEOUT
     });
     return res.text();
-  } catch (error) {
-    console.log('[events] Error sending event data to webhook', to, JSON.stringify(error));
-    return;
+  } catch (error: any) {
+    if (error.message.includes('network timeout')) {
+      console.error('[events] Timed out while sending the webhook', to);
+    } else {
+      console.error('[events] Error sending event data to webhook', to, JSON.stringify(error));
+    }
+
+    throw error;
   }
 }
 
@@ -95,7 +102,7 @@ const sendEventToWebhookSubscribers = (event, subscribers) => {
       .map(subscriber => sendEvent(event, subscriber.url))
   )
     .then(() => console.log('[events] Process event done'))
-    .catch(e => console.log('[events] Process event failed', e));
+    .catch(e => capture(e));
 };
 
 async function processEvents(subscribers) {


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

Outgoing webhook to subscribers does not have timeout, and rely on OS timeout value, which is pretty high. We should send, then close all outgoing requests as fast as possible, and not have slow subscribers hogging our connections pools.

## 💊 Fixes / Solution

Set a lower timeout value for outgoing request: 15s

This will fix all the timeout errors in the log.

## 🚧 Changes

- Add `timeout` property to outgoing fetch request
- Use `node-fetch` instead of `cross-fetch`. This is a node-only project, we don't need browser nor react native support.
- Throw errors on `fetch` errors, else the `Promise.allSettled()` will always see all promises as resolved.
- Print a dedicate error message on time out errors

## 🛠️ Tests

- add a slow subscriber to your database, like `https://httpstat.us/200?sleep=30000`
- `yarn dev`, and see outgoing requests in your console
- it should print a timeout error message for all webhooks sent to the slow endpoint 

## Notes

Maybe also add the new timeout value to the docs. It is subscribers responsability to be ready to receive the webhook, and close the connection in a timely manner.
