### PR TITLE
fix: do not capture error on invalid user input

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -26,8 +26,10 @@ router.get('/test', async (req, res) => {
     new URL(url);
     await sendEvent(event, url);
     return res.json({ url, success: true });
-  } catch (e) {
-    capture(e);
+  } catch (e: any) {
+    if (e.code !== 'ERR_INVALID_URL') {
+      capture(e);
+    }
     return res.json({ url, error: e });
   }
 });


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

When use input an invalid url while using the `/api/test` endpoint, it raises and send the error to sentry

## 💊 Fixes / Solution

Invalid user input such as invalid URL should not be logged to sentry, reducing noise

Fix #73 

## 🚧 Changes

- Do not sent the `INVALID_URL` error to sentry

## 🛠️ Tests

