### PR TITLE
fix: limit the button label length

### DIFF
--- a/src/discord.ts
+++ b/src/discord.ts
@@ -305,7 +305,7 @@ export const sendEventToDiscordSubscribers = async (event, proposalId) => {
           new ActionRowBuilder().addComponents(
             ...proposal.choices.map((choice, i) =>
               new ButtonBuilder()
-                .setLabel(choice)
+                .setLabel(choice.slice(0, 79))
                 .setURL(`${url}?choice=${i + 1}`)
                 .setStyle(ButtonStyle.Link)
             )


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

When creating a discord vote button from the proposal choices, the choice string is passed as-is to the button as label. In the case where choice is > 80 characters, it will trigger an exception from discord.js, which is expecting a button with max 80 characters.

## 💊 Fixes / Solution

Limit the number of characters in the button

Fix #75 

## 🚧 Changes

- Call `slice()` to limit the number of characters in the button to the limit set by discord.js

## 🛠️ Tests

