### PR TITLE
chore: fix 404 error on home page

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,18 +1,8 @@
 import express from 'express';
 import { sendEvent } from './events';
-import pkg from '../package.json';
-import { last_mci } from './replay';
 import { capture } from '@snapshot-labs/snapshot-sentry';
 
 const router = express.Router();
-
-router.get('/', async (req, res) => {
-  return res.json({
-    name: pkg.name,
-    version: pkg.version,
-    last_mci
-  });
-});
 
 router.get('/test', async (req, res) => {
   const url: any = req.query.url || '';

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,9 @@ import cors from 'cors';
 import { initLogger, fallbackLogger } from '@snapshot-labs/snapshot-sentry';
 import initMetrics from './helpers/metrics';
 import api from './api';
-import './replay';
 import './discord';
+import pkg from '../package.json';
+import { last_mci, run } from './replay';
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -14,12 +15,33 @@ const PORT = process.env.PORT || 3000;
 initLogger(app);
 initMetrics(app);
 
+run();
+
 app.use(bodyParser.json({ limit: '8mb' }));
 app.use(bodyParser.urlencoded({ limit: '8mb', extended: false }));
 app.use(cors({ maxAge: 86400 }));
 
+app.get('/', async (req, res) => {
+  return res.json({
+    name: pkg.name,
+    version: pkg.version,
+    last_mci
+  });
+});
+
 app.use('/api', api);
 
 fallbackLogger(app);
+
+app.use((_, res) => {
+  return res.status(404).json({
+    jsonrpc: '2.0',
+    error: {
+      code: 404,
+      message: 'PAGE_NOT_FOUND'
+    },
+    id: ''
+  });
+});
 
 app.listen(PORT, () => console.log(`Listening at http://localhost:${PORT}`));

--- a/src/replay.ts
+++ b/src/replay.ts
@@ -81,7 +81,7 @@ async function processMessages(messages: any[]) {
   return;
 }
 
-async function run() {
+export async function run() {
   // Check latest indexed MCI from db
   const lastMci = await getLastMci();
   console.log('[replay] Last MCI', lastMci);
@@ -96,5 +96,3 @@ async function run() {
   await snapshot.utils.sleep(10e3);
   return run();
 }
-
-run();


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

Requesting the root (https://webhook.snapshot.org/) is resulting in a 404 error.
The expected '/' route has been nested under /api

## 💊 Fixes / Solution

Move back the root router to index.ts

## 🚧 Changes

- `/` should display the usual JSON as other services
- add a catch-all routes to return 404 error as JSON, instead of express default format

## 🛠️ Tests

- `yarn start`
- Go to `http://localhost:3000/`
- It should display a JSON object 

- Go to `http://localhost:3000/ddsddsd`
- It should display a JSON response, with status code 404