### PR TITLE
fix: fix missing try/catch on subgraph queries

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,5 +4,10 @@ on: [push]
 
 jobs:
   lint:
+    strategy:
+      matrix:
+        target: ['18']
     uses: snapshot-labs/actions/.github/workflows/lint.yml@main
     secrets: inherit
+    with:
+      target: ${{ matrix.target }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,10 +4,5 @@ on: [push]
 
 jobs:
   lint:
-    strategy:
-      matrix:
-        target: ['18']
     uses: snapshot-labs/actions/.github/workflows/lint.yml@main
     secrets: inherit
-    with:
-      target: ${{ matrix.target }}

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -25,8 +25,8 @@ export async function getSubscribers(space) {
   try {
     const result = await snapshot.utils.subgraphRequest(`${HUB_URL}/graphql`, query);
     subscriptions = result.subscriptions || [];
-  } catch (error) {
-    capture(error);
+  } catch (e: any) {
+    capture(e, { contexts: { input: { query, space } } });
   }
   return subscriptions.map(subscription => subscription.address);
 }
@@ -55,12 +55,18 @@ export async function getProposal(id) {
       snapshot: true
     }
   };
-  const result = await snapshot.utils.subgraphRequest(`${HUB_URL}/graphql`, query);
-  if (result.errors) {
-    throw new Error(`[events] Errors in subgraph request for proposal id: ${id}`);
+
+  try {
+    const result = await snapshot.utils.subgraphRequest(`${HUB_URL}/graphql`, query);
+    if (result.errors) {
+      console.error(`[events] Errors in subgraph request for proposal id: ${id}`);
+    }
+    proposal = result.proposal || null;
+    return proposal;
+  } catch (e: any) {
+    capture(e, { contexts: { input: { query, id } } });
+    return null;
   }
-  proposal = result.proposal || null;
-  return proposal;
 }
 
 export async function getSpace(id) {
@@ -74,10 +80,15 @@ export async function getSpace(id) {
       name: true
     }
   };
-  const result = await snapshot.utils.subgraphRequest(`${HUB_URL}/graphql`, query);
-  if (result.errors) {
-    throw new Error(`[events] Errors in subgraph request for proposal id: ${id}`);
+  try {
+    const result = await snapshot.utils.subgraphRequest(`${HUB_URL}/graphql`, query);
+    if (result.errors) {
+      console.error(`[events] Errors in subgraph request for proposal id: ${id}`);
+    }
+    space = result.space || null;
+    return space;
+  } catch (e: any) {
+    capture(e, { contexts: { input: { query, id } } });
+    return null;
   }
-  space = result.space || null;
-  return space;
 }

--- a/src/replay.ts
+++ b/src/replay.ts
@@ -39,8 +39,8 @@ async function getNextMessages(mci: number) {
   try {
     const results = await snapshot.utils.subgraphRequest(`${hubURL}/graphql`, query);
     return results.messages;
-  } catch (e) {
-    capture(e);
+  } catch (e: any) {
+    capture(e, { contexts: { input: { query, mci } } });
     console.log('Failed to load messages', e);
     return;
   }


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

Some calls to snapshot.js (`snapshot.utils.subgraphRequest`) are not wrapped in a try/catch, raising the Sentry error https://snapshot-labs.sentry.io/issues/4415907506/?project=4505506867707904&referrer=github_integration

## 💊 Fixes / Solution

Fix #92 
Fix [SNAPSHOT-WEBHOOK-J](https://snapshot-labs.sentry.io/issues/4415907506/?referrer=github_integration)

Wrap the call in a `try/catch`

## 🚧 Changes

- Wrap all `snapshot.utils.subgraphRequest` in a try/catch
- Add more contexts to the logged error messages
- Bump node version to 18 on the github actions workflows

## 🛠️ Tests

- N/A