### PR TITLE
chore: update CI workflows to use node 18

### DIFF
--- a/.github/workflows/create-sentry-release.yml
+++ b/.github/workflows/create-sentry-release.yml
@@ -7,7 +7,11 @@ on:
 
 jobs:
   create-sentry-release:
+    strategy:
+      matrix:
+        target: ['18']
     uses: snapshot-labs/actions/.github/workflows/create-sentry-release.yml@main
     secrets: inherit
     with:
       project: snapshot-webhook
+      target: ${{ matrix.target }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,5 +4,10 @@ on: [push]
 
 jobs:
   lint:
+    strategy:
+      matrix:
+        target: ['18']
     uses: snapshot-labs/actions/.github/workflows/lint.yml@main
     secrets: inherit
+    with:
+      target: ${{ matrix.target }}


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

Current CI workflows are running on node 16, whereas the app is requiring node 18

## 💊 Fixes / Solution

Update CI tasks to run on node 18

## 🚧 Changes

- Update CI task to run on node 18

## 🛠️ Tests

- N/A