### PR TITLE
fix: add support for HTTP method customization in test endpoint

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -6,6 +6,7 @@ const router = express.Router();
 
 router.get('/test', async (req, res) => {
   const url: any = req.query.url || '';
+  const method: any = req.query.method || 'POST';
   const event = {
     id: `proposal/0x38c654c0f81b63ea1839ec3b221fad6ecba474aa0c4e8b4e8bc957f70100e753`,
     space: 'pistachiodao.eth',
@@ -15,7 +16,7 @@ router.get('/test', async (req, res) => {
 
   try {
     new URL(url);
-    await sendEvent(event, url);
+    await sendEvent(event, url, method);
 
     return res.json({ url, success: true });
   } catch (e: any) {


### PR DESCRIPTION
Allow customizing the HTTP method (post/get) when using the `api/test` endpoint