### PR TITLE
fix: fix GET http request failing

### DIFF
--- a/src/providers/webhook.ts
+++ b/src/providers/webhook.ts
@@ -22,10 +22,11 @@ export async function sendEvent(event, to, method = 'POST') {
         'Content-Type': 'application/json',
         Authentication: headerSecret
       },
-      body: JSON.stringify(event),
-      timeout: HTTP_WEBHOOK_TIMEOUT
+      timeout: HTTP_WEBHOOK_TIMEOUT,
+      ...(method === 'POST' ? { body: JSON.stringify(event) } : {})
     });
-    return res.text();
+
+    return true;
   } catch (error: any) {
     if (error.message.includes('network timeout')) {
       console.error('[webhook] request timed out', url);


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

Sending HTTP webhook using the `GET` method is failing. This error is not bubbling up to Sentry, as `Promise.allSettled` is eating the error.

## 💊 Fixes / Solution

Error is due to the presence of the `body` property, which is not allowed in a GET request

## 🚧 Changes

- Set the `body` property only if it is a `POST` request

## 🛠️ Tests

- Use the `api/test` endpoint (depends on https://github.com/snapshot-labs/snapshot-webhook/pull/99)