### PR TITLE
chore: upgrade metrics to support pushgateway

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "@snapshot-labs/*"

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   "prettier": "@snapshot-labs/prettier-config",
   "dependencies": {
     "@pusher/push-notifications-server": "^1.2.5",
-    "@snapshot-labs/snapshot-metrics": "^1.0.0",
-    "@snapshot-labs/snapshot-sentry": "^1.1.0",
+    "@snapshot-labs/snapshot-metrics": "^1.1.0",
+    "@snapshot-labs/snapshot-sentry": "^1.4.0",
     "@snapshot-labs/snapshot.js": "^0.3.68",
     "@xmtp/xmtp-js": "^10.2.0",
     "bluebird": "^3.7.2",

--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -6,7 +6,7 @@ import db from './mysql';
 export default function initMetrics(app: Express) {
   init(app, {
     whitelistedPath: [/^\/$/, /^\/api\/test$/],
-    errorHandler: (e: any) => capture(e)
+    errorHandler: capture
   });
 }
 

--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -1,10 +1,12 @@
 import init, { client } from '@snapshot-labs/snapshot-metrics';
-import db from './mysql';
 import type { Express } from 'express';
+import { capture } from '@snapshot-labs/snapshot-sentry';
+import db from './mysql';
 
 export default function initMetrics(app: Express) {
   init(app, {
-    whitelistedPath: [/^\/$/, /^\/api\/test$/]
+    whitelistedPath: [/^\/$/, /^\/api\/test$/],
+    errorHandler: (e: any) => capture(e)
   });
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -950,18 +950,18 @@
   resolved "https://registry.yarnpkg.com/@snapshot-labs/prettier-config/-/prettier-config-0.1.0-beta.7.tgz#c8e07e7e9baabee245020a72ac05835b65139823"
   integrity sha512-k/FUf4VWhwLFUmKuWs2mNvmPe691hqhvCJuujD4TfbIivWysmL1TqthwfdQUrQEAQUqVQ2ZKEiGkbufp5J27eQ==
 
-"@snapshot-labs/snapshot-metrics@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@snapshot-labs/snapshot-metrics/-/snapshot-metrics-1.0.0.tgz#1f88a6aacc81f639f7059c153b53c550934cd3b3"
-  integrity sha512-6T8a2NX6Qo6zVAoNIWV8eSJCukCynI/HCLp37VZTzX8jwU/ahGsiDTQC3I/MDus+LDB+8pI5nju33NwM8Q7n2g==
+"@snapshot-labs/snapshot-metrics@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@snapshot-labs/snapshot-metrics/-/snapshot-metrics-1.1.0.tgz#0b700ed50a28400cae7bfa47de9f5a1cc018719a"
+  integrity sha512-KajdSDd7cjQ9pRRYLDMqSd6yTcQ7Ln2/1zrRY5w23vGTSAH/NF0/7XojPYiW+IIdVAa5fV5nrcjFXT1X62XSYA==
   dependencies:
     express-prom-bundle "^6.6.0"
     prom-client "^14.2.0"
 
-"@snapshot-labs/snapshot-sentry@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@snapshot-labs/snapshot-sentry/-/snapshot-sentry-1.1.0.tgz#b357d4789ffd287f90fb70e7f0b207b47627cf24"
-  integrity sha512-Z31Y/5RJkTudrUwPasRxfABEQG2eQ2Ka5+vpi5zEwspt5gwTEfVM8M1NlYMFikWYqXHvVk51EU3UmJTqgL6pIg==
+"@snapshot-labs/snapshot-sentry@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@snapshot-labs/snapshot-sentry/-/snapshot-sentry-1.4.0.tgz#77933c2d8a32bb1b8daa05fec78ea73f8b78258d"
+  integrity sha512-261ZJGQ1rsSnAqsPrED1Hn2CoRFLtGla2WfnhqddcfYfYgEx2hsxUGs0jpSBCSfY/AsfK1+MgsoIXOFWXu74qQ==
   dependencies:
     "@sentry/node" "^7.60.1"
 


### PR DESCRIPTION
## Changes 

- Update snapshot-sentry to latest version (add support to capture JSON-RPC error)
- Update snapshot-metrics to latest version (add pushgateway support)
- Add dependabot to update @snapshot-labs packages