### PR TITLE
fix: use existing metrics to track XMTP subscribers count

### DIFF
--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -48,7 +48,18 @@ export const timeOutgoingRequest = new client.Histogram({
   buckets: [0.5, 1, 2, 5, 10, 15]
 });
 
-export const incomingXmtpMessages = new client.Gauge({
-  name: 'incoming_xmtp_messages_count',
+export const xmtpIncomingMessages = new client.Gauge({
+  name: 'xmtp_incoming_messages_count',
   help: 'Number of incoming XMTP messages'
+});
+
+new client.Gauge({
+  name: 'xmtp_subscribers_count',
+  help: 'Number of XMTP subscribers',
+  async collect() {
+    this.set(
+      (await db.queryAsync(`SELECT count(address) as count FROM xmtp WHERE status = 1`))[0]
+        .count as any
+    );
+  }
 });

--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -38,6 +38,10 @@ new client.Gauge({
       { type: 'discord' },
       (await db.queryAsync(`SELECT count(*) as count FROM subscriptions`))[0].count as any
     );
+    this.set(
+      { type: 'xmtp' },
+      (await db.queryAsync(`SELECT count(*) as count FROM xmtp WHERE status = 1`))[0].count as any
+    );
   }
 });
 
@@ -51,15 +55,4 @@ export const timeOutgoingRequest = new client.Histogram({
 export const xmtpIncomingMessages = new client.Gauge({
   name: 'xmtp_incoming_messages_count',
   help: 'Number of incoming XMTP messages'
-});
-
-new client.Gauge({
-  name: 'xmtp_subscribers_count',
-  help: 'Number of XMTP subscribers',
-  async collect() {
-    this.set(
-      (await db.queryAsync(`SELECT count(address) as count FROM xmtp WHERE status = 1`))[0]
-        .count as any
-    );
-  }
 });

--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -47,3 +47,8 @@ export const timeOutgoingRequest = new client.Histogram({
   labelNames: ['method', 'status', 'provider'],
   buckets: [0.5, 1, 2, 5, 10, 15]
 });
+
+export const incomingXmtpMessages = new client.Gauge({
+  name: 'incoming_xmtp_messages_count',
+  help: 'Number of incoming XMTP messages'
+});

--- a/src/providers/xmtp.ts
+++ b/src/providers/xmtp.ts
@@ -2,7 +2,7 @@ import { ApiUrls, Client } from '@xmtp/xmtp-js';
 import { Wallet } from '@ethersproject/wallet';
 import { getSpace } from '../helpers/utils';
 import db from '../helpers/mysql';
-import { timeOutgoingRequest } from '../helpers/metrics';
+import { incomingXmtpMessages, timeOutgoingRequest } from '../helpers/metrics';
 import { capture } from '@snapshot-labs/snapshot-sentry';
 
 const XMTP_PK = process.env.XMTP_PK || Wallet.createRandom().privateKey;
@@ -39,6 +39,7 @@ if (XMTP_PK) {
       try {
         if (message.senderAddress == client.address) continue;
         console.log(`[xmtp] received: ${message.senderAddress}:`, message.content);
+        incomingXmtpMessages.inc();
         const address = message.senderAddress.toLowerCase();
 
         if (message.content.toLowerCase() === 'stop') {

--- a/src/providers/xmtp.ts
+++ b/src/providers/xmtp.ts
@@ -2,7 +2,7 @@ import { ApiUrls, Client } from '@xmtp/xmtp-js';
 import { Wallet } from '@ethersproject/wallet';
 import { getSpace } from '../helpers/utils';
 import db from '../helpers/mysql';
-import { incomingXmtpMessages, timeOutgoingRequest } from '../helpers/metrics';
+import { xmtpIncomingMessages, timeOutgoingRequest } from '../helpers/metrics';
 import { capture } from '@snapshot-labs/snapshot-sentry';
 
 const XMTP_PK = process.env.XMTP_PK || Wallet.createRandom().privateKey;
@@ -39,7 +39,7 @@ if (XMTP_PK) {
       try {
         if (message.senderAddress == client.address) continue;
         console.log(`[xmtp] received: ${message.senderAddress}:`, message.content);
-        incomingXmtpMessages.inc();
+        xmtpIncomingMessages.inc();
         const address = message.senderAddress.toLowerCase();
 
         if (message.content.toLowerCase() === 'stop') {


### PR DESCRIPTION
Use the existing `subscribers_per_type_count` to track the subscribers count, instead of having a dedicated metric