### PR TITLE
fix: Don't allow duplicates for URL + space

### DIFF
--- a/src/helpers/schema.sql
+++ b/src/helpers/schema.sql
@@ -23,7 +23,7 @@ CREATE TABLE subscribers (
   space VARCHAR(256) NOT NULL,
   active INT(11) NOT NULL DEFAULT 1,
   created INT(11) NOT NULL DEFAULT (UNIX_TIMESTAMP()),
-  UNIQUE KEY unique_url_space (url, space),
+  UNIQUE KEY unique_url_space (url(255), space),
   PRIMARY KEY (id),
   INDEX owner (owner),
   INDEX space (space),

--- a/src/helpers/schema.sql
+++ b/src/helpers/schema.sql
@@ -23,6 +23,7 @@ CREATE TABLE subscribers (
   space VARCHAR(256) NOT NULL,
   active INT(11) NOT NULL DEFAULT 1,
   created INT(11) NOT NULL DEFAULT (UNIX_TIMESTAMP()),
+  UNIQUE KEY unique_url_space (url, space),
   PRIMARY KEY (id),
   INDEX owner (owner),
   INDEX space (space),


### PR DESCRIPTION
Run following SQL on prod webhook DB
- [x] ```SQL ALTER TABLE subscribers ADD CONSTRAINT unique_url_space UNIQUE (url(255), space); ```