### PR TITLE
fix: disable unused Beams provider

### DIFF
--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,12 +1,12 @@
 import { send as webhook } from './webhook';
 import { send as discord } from './discord';
-import { send as beams } from './beams';
+// import { send as beams } from './beams';
 import { send as xmtp } from './xmtp';
 
 export default [
   // Comment a line to disable a provider
   webhook,
   discord,
-  beams,
+  // beams,
   xmtp
 ];


### PR DESCRIPTION
Following on https://discord.com/channels/955773041898573854/1031838169282392144/1182256340144508999

Disable provider because:

- pusher subscription is over the limit
- we don't use push notifications anymore on the UI

