### PR TITLE
chore: stop sending discord error to sentry

### DIFF
--- a/src/providers/discord.ts
+++ b/src/providers/discord.ts
@@ -11,7 +11,8 @@ import {
   EmbedBuilder,
   codeBlock,
   underscore,
-  inlineCode
+  inlineCode,
+  DiscordAPIError
 } from 'discord.js';
 import db from '../helpers/mysql';
 import removeMd from 'remove-markdown';
@@ -146,6 +147,9 @@ const checkPermissions = async (channelId, botId) => {
       return `I do not have permission to send messages in this channel ${discordChannel.toString()}, Add permission and try again`;
     return true;
   } catch (error) {
+    if (!(error instanceof DiscordAPIError)) {
+      capture(error);
+    }
     console.error('[discord] error checking permissions', error);
     const channelExistWithName = client.channels.cache.find(
       c => c.name === channelId
@@ -319,8 +323,11 @@ export const sendMessage = async (channel, message) => {
     await speaker.send(message);
     success = true;
     return true;
-  } catch (e) {
-    console.error('[discord] Failed to send message', channel, e);
+  } catch (error) {
+    if (!(error instanceof DiscordAPIError)) {
+      capture(error);
+    }
+    console.error('[discord] Failed to send message', channel, error);
   } finally {
     end({ status: success ? 200 : 500 });
   }

--- a/src/providers/discord.ts
+++ b/src/providers/discord.ts
@@ -146,8 +146,7 @@ const checkPermissions = async (channelId, botId) => {
       return `I do not have permission to send messages in this channel ${discordChannel.toString()}, Add permission and try again`;
     return true;
   } catch (error) {
-    capture(error);
-    console.log('[discord] error checking permissions', error);
+    console.error('[discord] error checking permissions', error);
     const channelExistWithName = client.channels.cache.find(
       c => c.name === channelId
     );
@@ -321,7 +320,7 @@ export const sendMessage = async (channel, message) => {
     success = true;
     return true;
   } catch (e) {
-    capture(e);
+    console.error('[discord] Failed to send message', channel, e);
   } finally {
     end({ status: success ? 200 : 500 });
   }


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

We are logging a lot of discord error, such as `Missing permission`, or `Channel not found`.

Those errors are not code related, and should not be logged on sentry, as we can not resolve them (these are more user errors)

## 💊 Fixes / Solution

Stop sending the errors on Sentry, and just log them with `console.error`, to be inline with what's already done with the user errors on the http webhook.

Fix SNAPSHOT-WEBHOOK-3
Fix SNAPSHOT-WEBHOOK-4
Fix SNAPSHOT-WEBHOOK-16
Fix SNAPSHOT-WEBHOOK-V
Fix SNAPSHOT-WEBHOOK-5

## 🚧 Changes

- Send all `DiscordAPIError` to console.error instead of Sentry