### PR TITLE
fix: fix error when bot permissions is null

### DIFF
--- a/src/providers/discord.ts
+++ b/src/providers/discord.ts
@@ -135,13 +135,13 @@ const checkPermissions = async (channelId, botId) => {
     if (
       !discordChannel
         .permissionsFor(botId)
-        .has(PermissionsBitField.Flags.ViewChannel)
+        ?.has(PermissionsBitField.Flags.ViewChannel)
     )
       return `I do not have permission to view this channel ${discordChannel.toString()}, Add me to the channel and try again`;
     if (
       !discordChannel
         .permissionsFor(botId)
-        .has(PermissionsBitField.Flags.SendMessages)
+        ?.has(PermissionsBitField.Flags.SendMessages)
     )
       return `I do not have permission to send messages in this channel ${discordChannel.toString()}, Add permission and try again`;
     return true;


### PR DESCRIPTION
Fix error when discord bot permission is `null`

Fix #157 
Fix [SNAPSHOT-WEBHOOK-15](https://snapshot-labs.sentry.io/issues/4843545157/?referrer=github_integration)