### PR TITLE
fix: fix variable scope

### DIFF
--- a/src/providers/discord.ts
+++ b/src/providers/discord.ts
@@ -329,9 +329,8 @@ export const sendMessage = async (channel, message) => {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export async function send(eventObj, proposal, _subscribers) {
+  const event = eventObj.event;
   try {
-    const event = eventObj.event;
-
     // Only supports proposal/start event
     if (event !== 'proposal/start') return;
 


### PR DESCRIPTION
Fix `event` variable not available in the capture scope

Fix #159 
Fix [SNAPSHOT-WEBHOOK-R](https://snapshot-labs.sentry.io/issues/4510290542/?referrer=github_integration)