### PR TITLE
fix: ignore fetch error from test endpoint

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -20,7 +20,7 @@ router.get('/test', async (req, res) => {
 
     return res.json({ url, success: true });
   } catch (e: any) {
-    if (e.code !== 'ERR_INVALID_URL') {
+    if (e.code !== 'ERR_INVALID_URL' && e.name !== 'FetchError') {
       capture(e);
     }
 


### PR DESCRIPTION
Ignore all `FetchError` from `api/test` endpoint, which are operation error from http (network timeout, error 500, etc ...).

Error details returned already as JSON RPC response, no need to log them to our error logger.

Fix SNAPSHOT-WEBHOOK-17