### PR TITLE
fix: fix metrics error on walletconnectNotify subscribers fetch error

### DIFF
--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -49,10 +49,11 @@ new client.Gauge({
         )
       )[0].count as any
     );
-    this.set(
-      { type: 'walletconnect' },
-      (await getSubscribersFromWalletConnect()).length
-    );
+
+    try {
+      const subscribers = await getSubscribersFromWalletConnect();
+      this.set({ type: 'walletconnect' }, subscribers.length);
+    } catch (e) {}
   }
 });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,6 @@
+export type Event = {
+  event: string;
+  space: string;
+  id: string;
+};
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,4 +3,3 @@ export type Event = {
   space: string;
   id: string;
 };
-}


### PR DESCRIPTION
Fix #166 
Closes [SNAPSHOT-WEBHOOK-18](https://snapshot-labs.sentry.io/issues/4894434203/?referrer=github_integration)

- Fix error when `getSubscribersFromWalletConnect` is failing
- Remove `wait` method, using `snapshot.utils.sleep` instead
- Add `console.log`