### PR TITLE
feat: track number of outgoing webhook messages

### DIFF
--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -67,3 +67,9 @@ export const xmtpIncomingMessages = new client.Gauge({
   name: 'xmtp_incoming_messages_count',
   help: 'Number of incoming XMTP messages'
 });
+
+export const outgoingMessages = new client.Gauge({
+  name: 'http_webhook_outgoing_messages_count',
+  help: 'Number of messages sent to webhooks.',
+  labelNames: ['status', 'provider']
+});

--- a/src/providers/beams.ts
+++ b/src/providers/beams.ts
@@ -1,7 +1,7 @@
 import PushNotifications from '@pusher/push-notifications-server';
 import chunk from 'lodash.chunk';
 import { capture } from '@snapshot-labs/snapshot-sentry';
-import { timeOutgoingRequest } from '../helpers/metrics';
+import { timeOutgoingRequest, outgoingMessages } from '../helpers/metrics';
 
 const SERVICE_PUSH_NOTIFICATIONS = parseInt(
   process.env.SERVICE_PUSH_NOTIFICATIONS || '0'
@@ -30,6 +30,7 @@ export async function send(event, proposal, subscribers) {
           }
         }
       });
+      outgoingMessages.inc({ status: 1 }, walletsChunk.length);
     }
     success = true;
   } catch (e) {

--- a/src/providers/discord.ts
+++ b/src/providers/discord.ts
@@ -19,7 +19,7 @@ import removeMd from 'remove-markdown';
 import { shortenAddress } from '../helpers/utils';
 import { getSpace } from '../helpers/utils';
 import { capture } from '@snapshot-labs/snapshot-sentry';
-import { timeOutgoingRequest } from '../helpers/metrics';
+import { timeOutgoingRequest, outgoingMessages } from '../helpers/metrics';
 
 const CLIENT_ID = process.env.DISCORD_CLIENT_ID || '';
 const token = process.env.DISCORD_TOKEN || '';
@@ -329,6 +329,7 @@ export const sendMessage = async (channel, message) => {
     }
     console.error('[discord] Failed to send message', channel, error);
   } finally {
+    outgoingMessages.inc({ status: success ? 1 : 0 });
     end({ status: success ? 200 : 500 });
   }
 };

--- a/src/providers/walletconnectNotify.ts
+++ b/src/providers/walletconnectNotify.ts
@@ -1,6 +1,6 @@
 import fetch from 'node-fetch';
 import { capture } from '@snapshot-labs/snapshot-sentry';
-import { timeOutgoingRequest } from '../helpers/metrics';
+import { timeOutgoingRequest, outgoingMessages } from '../helpers/metrics';
 
 const WALLETCONNECT_NOTIFY_SERVER_URL =
   process.env.WALLETCONNECT_NOTIFY_SERVER_URL;
@@ -88,7 +88,7 @@ async function queueNotificationsToSend(notification, accounts: string[]) {
   }
 }
 
-export async function sendNotification(notification, accounts) {
+export async function sendNotification(notification, accounts: string[]) {
   const notifyUrl = `${WALLETCONNECT_NOTIFY_SERVER_URL}/${WALLETCONNECT_PROJECT_ID}/notify`;
 
   const body = {
@@ -115,6 +115,7 @@ export async function sendNotification(notification, accounts) {
   } catch (e) {
     capture('[WalletConnect] failed to notify subscribers', e);
   } finally {
+    outgoingMessages.inc({ status: success ? 1 : 0 }, accounts.length);
     end({ status: success ? 200 : 500 });
   }
 }

--- a/src/providers/webhook.ts
+++ b/src/providers/webhook.ts
@@ -2,7 +2,7 @@ import fetch from 'node-fetch';
 import { capture } from '@snapshot-labs/snapshot-sentry';
 import db from '../helpers/mysql';
 import { sha256 } from '../helpers/utils';
-import { timeOutgoingRequest } from '../helpers/metrics';
+import { timeOutgoingRequest, outgoingMessages } from '../helpers/metrics';
 
 const HTTP_WEBHOOK_TIMEOUT = 15000;
 const serviceEventsSalt = parseInt(process.env.SERVICE_EVENTS_SALT || '12345');
@@ -35,6 +35,7 @@ export async function sendEvent(event, to, method = 'POST') {
     }
     throw error;
   } finally {
+    outgoingMessages.inc({ status: res?.status === 200 ? 1 : 0 });
     end({ status: res?.status || 0 });
   }
 }


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

The current instrumentation method only track the number of outgoing requests call, and assumes that one call = one message sent to one subscriber

This was true for HTTP, Discord and XMTP, but not for Beams and WalletConnect, which uses batch sending

This means that we do not have reliable metrics for number of messages sent to users for Beams and walletConnect

## 💊 Fixes / Solution

Add a new `http_webhook_outgoing_messages_count` metrics to track the number of messages sent to subscriber
