### PR TITLE
fix: fix missing provider property in outgoingMessages metric

### DIFF
--- a/src/providers/beams.ts
+++ b/src/providers/beams.ts
@@ -30,7 +30,10 @@ export async function send(event, proposal, subscribers) {
           }
         }
       });
-      outgoingMessages.inc({ status: 1 }, walletsChunk.length);
+      outgoingMessages.inc(
+        { provider: 'beams', status: 1 },
+        walletsChunk.length
+      );
     }
     success = true;
   } catch (e) {

--- a/src/providers/discord.ts
+++ b/src/providers/discord.ts
@@ -329,7 +329,7 @@ export const sendMessage = async (channel, message) => {
     }
     console.error('[discord] Failed to send message', channel, error);
   } finally {
-    outgoingMessages.inc({ status: success ? 1 : 0 });
+    outgoingMessages.inc({ provider: 'discord', status: success ? 1 : 0 });
     end({ status: success ? 200 : 500 });
   }
 };

--- a/src/providers/walletconnectNotify.ts
+++ b/src/providers/walletconnectNotify.ts
@@ -112,7 +112,10 @@ export async function sendNotification(notification, accounts: string[]) {
     capture(e);
     console.log('[WalletConnect] failed to notify subscribers', e);
   } finally {
-    outgoingMessages.inc({ status: success ? 1 : 0 }, accounts.length);
+    outgoingMessages.inc(
+      { provider: 'walletconnect', status: success ? 1 : 0 },
+      accounts.length
+    );
     end({ status: success ? 200 : 500 });
   }
 }

--- a/src/providers/webhook.ts
+++ b/src/providers/webhook.ts
@@ -35,7 +35,10 @@ export async function sendEvent(event, to, method = 'POST') {
     }
     throw error;
   } finally {
-    outgoingMessages.inc({ status: res?.status === 200 ? 1 : 0 });
+    outgoingMessages.inc({
+      provider: 'http',
+      status: res?.status === 200 ? 1 : 0
+    });
     end({ status: res?.status || 0 });
   }
 }

--- a/src/providers/xmtp.ts
+++ b/src/providers/xmtp.ts
@@ -119,11 +119,11 @@ async function sendMessages(addresses: string[], msg) {
         const conversation = await client.conversations.newConversation(peer);
         await conversation.send(msg);
         end({ status: 200 });
-        outgoingMessages.inc({ status: 1 });
+        outgoingMessages.inc({ provider: 'xmtp', status: 1 });
         console.log('[xmtp] sent message to', peer);
       } catch (e: any) {
         capture(e);
-        outgoingMessages.inc({ status: 0 });
+        outgoingMessages.inc({ provider: 'xmtp', status: 0 });
         end({ status: 500 });
       }
     }


### PR DESCRIPTION
Fix missing `provider` label in `outgoingMessages` metric introduced in #168 