### PR TITLE
fix: avoid expensive network requests by using chain agnostic notify

### DIFF
--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -2,7 +2,6 @@ import init, { client } from '@snapshot-labs/snapshot-metrics';
 import type { Express } from 'express';
 import { capture } from '@snapshot-labs/snapshot-sentry';
 import db from './mysql';
-import { getSubscribersFromWalletConnect } from '../providers/walletconnectNotify';
 
 export default function initMetrics(app: Express) {
   init(app, {
@@ -49,11 +48,6 @@ new client.Gauge({
         )
       )[0].count as any
     );
-
-    try {
-      const subscribers = await getSubscribersFromWalletConnect();
-      this.set({ type: 'walletconnect' }, subscribers.length);
-    } catch (e) {}
   }
 });
 

--- a/src/providers/walletconnectNotify.ts
+++ b/src/providers/walletconnectNotify.ts
@@ -23,56 +23,6 @@ const PER_SECOND_RATE_LIMIT = 2;
 const WAIT_ERROR_MARGIN = 0.25;
 const WAIT_TIME = 1 / PER_SECOND_RATE_LIMIT + WAIT_ERROR_MARGIN;
 
-// Fetch subscribers from WalletConnect Notify server
-export async function getSubscribersFromWalletConnect() {
-  const fetchSubscribersUrl = `${WALLETCONNECT_NOTIFY_SERVER_URL}/${WALLETCONNECT_PROJECT_ID}/subscribers`;
-
-  try {
-    const subscribersRs = await fetch(fetchSubscribersUrl, {
-      headers: AUTH_HEADER
-    });
-
-    const subscribers: string[] = await subscribersRs.json();
-
-    return subscribers;
-  } catch (e) {
-    capture(e);
-    console.log('[WalletConnect] failed to fetch subscribers');
-    return [];
-  }
-}
-
-// Find the CAIP10 of subscribers, since the Notify API requires CAIP10.
-async function crossReferenceSubscribers(
-  space: { id: string },
-  spaceSubscribers
-) {
-  const subscribersFromDb = spaceSubscribers;
-  const subscribersFromWalletConnect = await getSubscribersFromWalletConnect();
-
-  // optimistically reserve all subscribers from the db
-  const crossReferencedSubscribers = new Array(subscribersFromDb.length);
-
-  // Create a hashmap for faster lookup
-  const addressPrefixMap = new Map<string, string>();
-  for (const subscriber of subscribersFromWalletConnect) {
-    const unprefixedAddress = subscriber.split(':').pop();
-    if (unprefixedAddress) {
-      addressPrefixMap.set(unprefixedAddress, subscriber);
-    }
-  }
-
-  for (const subscriber of subscribersFromDb) {
-    const crossReferencedAddress = addressPrefixMap.get(subscriber);
-    if (crossReferencedAddress) {
-      crossReferencedSubscribers.push(crossReferencedAddress);
-    }
-  }
-
-  // remove empty elements from the array, since some might not have been found in WalletConnect Notify server
-  return crossReferencedSubscribers.filter(addresses => addresses);
-}
-
 async function queueNotificationsToSend(notification, accounts: string[]) {
   for (let i = 0; i < accounts.length; i += MAX_ACCOUNTS_PER_REQUEST) {
     await sendNotification(
@@ -138,16 +88,14 @@ function formatMessage(event: Event, proposal) {
   };
 }
 
-export async function send(event: Event, proposal, subscribers: string[]) {
+export async function send(event: Event, proposal, addresses: string[]) {
   if (event.event !== 'proposal/start') return;
-  const crossReferencedSubscribers = await crossReferenceSubscribers(
-    proposal.space,
-    subscribers
-  );
   const notificationMessage = formatMessage(event, proposal);
+
+  const accounts = addresses.map(address => `eip155:1:${address}`);
 
   await queueNotificationsToSend(
     notificationMessage,
-    crossReferencedSubscribers
+    accounts,
   );
 }

--- a/src/providers/walletconnectNotify.ts
+++ b/src/providers/walletconnectNotify.ts
@@ -94,8 +94,5 @@ export async function send(event: Event, proposal, addresses: string[]) {
 
   const accounts = addresses.map(address => `eip155:1:${address}`);
 
-  await queueNotificationsToSend(
-    notificationMessage,
-    accounts,
-  );
+  await queueNotificationsToSend(notificationMessage, accounts);
 }


### PR DESCRIPTION
Remove `GET /subscribers` lookup in-favor of chain-agnostic handling that is now built-into the `/notify` endpoint. Avoids expensive network requests and mapping logic. Instead, an arbitrary chain ID prefix can be used (in this case `eip155:1`) and Notify Server will now find the correct account with the same address internally.