### PR TITLE
[walletConnectNotify] fix: Remove icon field and throw error if there is an error in response

### DIFF
--- a/src/providers/walletconnectNotify.ts
+++ b/src/providers/walletconnectNotify.ts
@@ -106,6 +106,9 @@ export async function sendNotification(notification, accounts: string[]) {
     });
 
     const notifySuccess = await notifyRs.json();
+    if (notifySuccess?.error) {
+      throw new Error(notifySuccess.error);
+    }
     success = true;
     return notifySuccess;
   } catch (e) {
@@ -133,7 +136,7 @@ function formatMessage(event: Event, proposal) {
     title: proposal.title,
     body: notificationBody,
     url,
-    icon: space.avatar,
+    icon: `https://cdn.stamp.fyi/space/${space.id}?s=96`,
     type: notificationType
   };
 }

--- a/src/providers/walletconnectNotify.ts
+++ b/src/providers/walletconnectNotify.ts
@@ -136,7 +136,6 @@ function formatMessage(event: Event, proposal) {
     title: proposal.title,
     body: notificationBody,
     url,
-    icon: `https://cdn.stamp.fyi/space/${space.id}?s=96`,
     type: notificationType
   };
 }


### PR DESCRIPTION
- [Not using `icon` field anymore ](https://docs.walletconnect.com/web3inbox/sending-notifications#sending-notifications-1)
- Right now we get an error in response, 
  ```javascript
  {
    error: 'icon: Validation error: length [{"value": String(""), "min": Number(1), "max": Number(255)}]'
  }
  ```
  and it is silent because we are not able to catch these errors