### PR TITLE
fix: fix error when last_mci is not initialized

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,11 @@ HUB_URL=https://hub.snapshot.org # Use https://testnet.hub.snapshot.org for the 
 SERVICE_EVENTS=1
 ```
 
-- Run [this MySQL query](src/helpers/schema.sql) to create tables on the database.
+- Set up the database (creates tables and initializes metadata):
+
+```shell
+yarn setup
+```
 
 - Comment line(s) on [this file](src/providers/index.ts) to disable provider(s).
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build": "tsc",
     "dev": "nodemon src/index.ts",
     "start": "node dist/src/index.js",
-    "test": "yarn jest"
+    "test": "yarn jest",
+    "setup": "ts-node scripts/setup.ts"
   },
   "eslintConfig": {
     "extends": "@snapshot-labs"

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -15,13 +15,14 @@ async function createTables() {
 
     // Remove comments and split by semicolon
     const cleanedSchema = schema
+      .replace(/\/\*[\s\S]*?\*\//g, '') // Remove block comments
       .split('\n')
       .map(line => line.trim())
       .filter(line => line && !line.startsWith('#') && !line.startsWith('--'))
       .join('\n');
 
     const statements = cleanedSchema
-      .split(';')
+      .split(/;\s*(?=(?:[^']*'[^']*')*[^']*$)/) // Split respecting quoted strings
       .map(stmt => stmt.trim())
       .filter(stmt => stmt);
 

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -1,0 +1,84 @@
+#!/usr/bin/env ts-node
+
+import 'dotenv/config';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import db from '../src/helpers/mysql';
+
+async function createTables() {
+  console.log('Creating database tables...');
+
+  try {
+    // Read schema file
+    const schemaPath = join(__dirname, '../src/helpers/schema.sql');
+    const schema = readFileSync(schemaPath, 'utf8');
+
+    // Remove comments and split by semicolon
+    const cleanedSchema = schema
+      .split('\n')
+      .map(line => line.trim())
+      .filter(line => line && !line.startsWith('#') && !line.startsWith('--'))
+      .join('\n');
+
+    const statements = cleanedSchema
+      .split(';')
+      .map(stmt => stmt.trim())
+      .filter(stmt => stmt);
+
+    // Execute each CREATE TABLE statement
+    for (const statement of statements) {
+      if (statement.toUpperCase().includes('CREATE TABLE')) {
+        try {
+          await db.queryAsync(statement);
+          const tableName = statement.match(/CREATE TABLE (\w+)/i)?.[1];
+          console.log(`✓ Table ${tableName} created or already exists`);
+        } catch (error: any) {
+          if (error.code === 'ER_TABLE_EXISTS_ERROR') {
+            const tableName = statement.match(/CREATE TABLE (\w+)/i)?.[1];
+            console.log(`✓ Table ${tableName} already exists`);
+          } else {
+            console.error('Error creating table:', error.message);
+          }
+        }
+      }
+    }
+  } catch (error) {
+    console.error('Error reading schema file or creating tables:', error);
+  }
+}
+
+async function initLastMci() {
+  console.log('Initializing last_mci metadata...');
+
+  try {
+    // Check if last_mci already exists
+    const checkQuery = 'SELECT value FROM _metadatas WHERE id = ? LIMIT 1';
+    const existing = await db.queryAsync(checkQuery, ['last_mci']);
+
+    if (existing && existing.length > 0) {
+      console.log('✓ last_mci already exists with value:', existing[0].value);
+      return;
+    }
+
+    // Insert initial last_mci value
+    const insertQuery = 'INSERT INTO _metadatas (id, value) VALUES (?, ?)';
+    await db.queryAsync(insertQuery, ['last_mci', '0']);
+
+    console.log('✓ Successfully initialized last_mci with value: 0');
+  } catch (error) {
+    console.error('Error initializing last_mci:', error);
+  }
+}
+
+async function setup() {
+  console.log('Starting database setup...\n');
+
+  await createTables();
+  console.log('');
+  await initLastMci();
+
+  console.log('\nDatabase setup completed!');
+  process.exit(0);
+}
+
+setup();

--- a/src/replay.ts
+++ b/src/replay.ts
@@ -11,7 +11,7 @@ export let last_mci = 0;
 async function getLastMci() {
   const query = 'SELECT value FROM _metadatas WHERE id = ? LIMIT 1';
   const results = await db.queryAsync(query, ['last_mci']);
-  last_mci = parseInt(results[0]?.value || "0");
+  last_mci = parseInt(results[0]?.value || '0');
   return last_mci;
 }
 

--- a/src/replay.ts
+++ b/src/replay.ts
@@ -11,7 +11,7 @@ export let last_mci = 0;
 async function getLastMci() {
   const query = 'SELECT value FROM _metadatas WHERE id = ? LIMIT 1';
   const results = await db.queryAsync(query, ['last_mci']);
-  last_mci = parseInt(results[0]?.value);
+  last_mci = parseInt(results[0]?.value || "0");
   return last_mci;
 }
 

--- a/src/replay.ts
+++ b/src/replay.ts
@@ -11,7 +11,7 @@ export let last_mci = 0;
 async function getLastMci() {
   const query = 'SELECT value FROM _metadatas WHERE id = ? LIMIT 1';
   const results = await db.queryAsync(query, ['last_mci']);
-  last_mci = parseInt(results[0].value);
+  last_mci = parseInt(results[0]?.value);
   return last_mci;
 }
 
@@ -50,8 +50,9 @@ async function getNextMessages(mci: number) {
 }
 
 async function updateLastMci(mci: number) {
-  const query = 'UPDATE _metadatas SET value = ? WHERE id = ? LIMIT 1';
-  await db.queryAsync(query, [mci.toString(), 'last_mci']);
+  const query =
+    'INSERT INTO _metadatas (value, id) VALUES (?, ?) ON DUPLICATE KEY UPDATE value = ?';
+  await db.queryAsync(query, [mci.toString(), 'last_mci', mci.toString()]);
 }
 
 async function processMessages(messages: any[]) {

--- a/src/replay.ts
+++ b/src/replay.ts
@@ -11,7 +11,7 @@ export let last_mci = 0;
 async function getLastMci() {
   const query = 'SELECT value FROM _metadatas WHERE id = ? LIMIT 1';
   const results = await db.queryAsync(query, ['last_mci']);
-  last_mci = parseInt(results[0]?.value || '0');
+  last_mci = parseInt(results[0].value);
   return last_mci;
 }
 
@@ -50,9 +50,8 @@ async function getNextMessages(mci: number) {
 }
 
 async function updateLastMci(mci: number) {
-  const query =
-    'INSERT INTO _metadatas (value, id) VALUES (?, ?) ON DUPLICATE KEY UPDATE value = ?';
-  await db.queryAsync(query, [mci.toString(), 'last_mci', mci.toString()]);
+  const query = 'UPDATE _metadatas SET value = ? WHERE id = ? LIMIT 1';
+  await db.queryAsync(query, [mci.toString(), 'last_mci']);
 }
 
 async function processMessages(messages: any[]) {


### PR DESCRIPTION
Fix an error when the `last_mci` is not initialized, like on a brand new database

Added a new `yarn setup` command to prep the database:

- creates the required table if not exist
- populate the table with the initial data (`last_mci`) if not exist