### PR TITLE
fix: disable xmtp provider

### DIFF
--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -2,13 +2,13 @@ import { send as webhook } from './webhook';
 import { send as walletconnectNotify } from './walletconnectNotify';
 import { send as discord } from './discord';
 // import { send as beams } from './beams';
-import { send as xmtp } from './xmtp';
+// import { send as xmtp } from './xmtp';
 
 export default [
   // Comment a line to disable a provider
   webhook,
   discord,
   // beams,
-  xmtp,
+  // xmtp,
   walletconnectNotify
 ];


### PR DESCRIPTION
Disable the xmtp provider because:

- it's the source of the memory leak issue (https://github.com/xmtp/xmtp-js/issues/538)
- the package is using an old api which is sunsetting on june 1st 2025: will require migrating to another package to support their new v3 api