### PR TITLE
fix: add try catch for entire `run`

### DIFF
--- a/src/replay.ts
+++ b/src/replay.ts
@@ -9,6 +9,10 @@ const hubURL = process.env.HUB_URL || 'https://hub.snapshot.org';
 export let last_mci = 0;
 
 async function getLastMci() {
+  if (Math.random() < 0.5) {
+    throw new Error('Simulated crash for testing');
+  }
+
   const query = 'SELECT value FROM _metadatas WHERE id = ? LIMIT 1';
   const results = await db.queryAsync(query, ['last_mci']);
   last_mci = parseInt(results[0].value);


### PR DESCRIPTION
Closes https://github.com/snapshot-labs/workflow/issues/510

<hr/>

### Issue:
For some reason, the `run` fails randomly , but server keeps running, this is causing the server to still run without `run`
In this case all we see is this logs
<img width="365" height="686" alt="image" src="https://github.com/user-attachments/assets/f33238ec-1219-45fb-b839-2be75f8a6f2d" />

But can't find any logs from `run`:
```
[replay] Last MCI 91950578
```
<hr/>

### Fix:

I assume it is because of some DB issue from `getLastMci`, i am able to reproduce same logs like above by adding this patch the code
```
diff --git a/src/replay.ts b/src/replay.ts
index 08d9be6..9a68275 100644
--- a/src/replay.ts
+++ b/src/replay.ts
@@ -8,7 +8,12 @@ const hubURL = process.env.HUB_URL || 'https://hub.snapshot.org';
 
 export let last_mci = 0;
 
+process.on('uncaughtException', () => {});
+
 async function getLastMci() {
+  if (Math.random() < 0.5) {
+    throw new Error('Simulated crash for testing');
+  }
   const query = 'SELECT value FROM _metadatas WHERE id = ? LIMIT 1';
   const results = await db.queryAsync(query, ['last_mci']);
   last_mci = parseInt(results[0].value);
```
But hard to recreate same DB issue to check, better to add a try catch for entire `run` and crash server in this case