### PR TITLE
fix: add timeout to node-fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@pusher/push-notifications-server": "^1.2.5",
     "@snapshot-labs/snapshot-metrics": "^1.4.1",
     "@snapshot-labs/snapshot-sentry": "^1.5.5",
-    "@snapshot-labs/snapshot.js": "^0.14.3",
+    "@snapshot-labs/snapshot.js": "^0.14.6",
     "@xmtp/xmtp-js": "^10.2.0",
     "bluebird": "^3.7.2",
     "body-parser": "^1.20.2",

--- a/src/providers/walletconnectNotify.ts
+++ b/src/providers/walletconnectNotify.ts
@@ -1,4 +1,3 @@
-import fetch from 'node-fetch';
 import snapshot from '@snapshot-labs/snapshot.js';
 import { capture } from '@snapshot-labs/snapshot-sentry';
 import { timeOutgoingRequest, outgoingMessages } from '../helpers/metrics';
@@ -67,7 +66,7 @@ export async function sendNotification(
   let success = false;
 
   try {
-    const notifyRs = await fetch(notifyUrl, {
+    const notifyRs = await snapshot.utils.fetch(notifyUrl, {
       method: 'POST',
       headers: {
         ...AUTH_HEADER,

--- a/src/providers/webhook.ts
+++ b/src/providers/webhook.ts
@@ -1,5 +1,5 @@
-import fetch from 'node-fetch';
 import { capture } from '@snapshot-labs/snapshot-sentry';
+import snapshot from '@snapshot-labs/snapshot.js';
 import db from '../helpers/mysql';
 import { sha256 } from '../helpers/utils';
 import { timeOutgoingRequest, outgoingMessages } from '../helpers/metrics';
@@ -16,7 +16,7 @@ export async function sendEvent(event, to, method = 'POST') {
   let res;
 
   try {
-    res = await fetch(url, {
+    res = await snapshot.utils.fetch(url, {
       method,
       headers: {
         'Content-Type': 'application/json',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1289,10 +1289,10 @@
   dependencies:
     "@sentry/node" "^7.81.1"
 
-"@snapshot-labs/snapshot.js@^0.14.3":
-  version "0.14.3"
-  resolved "https://registry.yarnpkg.com/@snapshot-labs/snapshot.js/-/snapshot.js-0.14.3.tgz#965e9ba241705cc72bc3857dffcc8241216ae2b0"
-  integrity sha512-O6u51T++jzZnmJ1E5Pkh0TIJyVBvfa5z9NuuT4mSPdmW8fNhndOTAlkdpk63TdQWaFaf+5axak3HfqTQz3Sbig==
+"@snapshot-labs/snapshot.js@^0.14.6":
+  version "0.14.6"
+  resolved "https://registry.yarnpkg.com/@snapshot-labs/snapshot.js/-/snapshot.js-0.14.6.tgz#bc41655f172ed64f71c205f2a65906bffd721b99"
+  integrity sha512-A7VcQqeggIDFhCpUbe8zzsvULlGCxDCtyuLC2nkAzpXOSzfP35cIZ2swzWboWmA6zF5y+bCgXfLAj3+PYYRRJQ==
   dependencies:
     "@ensdomains/eth-ens-namehash" "^2.0.15"
     "@ethersproject/abi" "^5.6.4"


### PR DESCRIPTION
The existing `fetch` requests are already using the `timeout` option, but it's not supported by the node-fetch version installed.,

Similar to https://github.com/snapshot-labs/snapshot-hub/pull/1036 , this PR will add support of the `timeout` option for all `fetch` operations, and will hopefully fix an issue with hanging requests, stalling the infinite loop