### PR TITLE
style: apply prettier printWidth 80

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,12 @@
 version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
     allow:
-      - dependency-name: "@snapshot-labs/*"
+      - dependency-name: '@snapshot-labs/*'
     groups:
       snapshot:
         patterns:
-          - "@snapshot-labs/*"
+          - '@snapshot-labs/*'

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Snapshot webhook
 
-Microservice to send Snapshot related notifications to multiple communication channels. 
+Microservice to send Snapshot related notifications to multiple communication channels.
 
 ### Get started
 
-- Fork this repository then run this command to install dependencies: 
+- Fork this repository then run this command to install dependencies:
+
 ```shell
 yarn install
 ```
@@ -26,6 +27,7 @@ yarn setup
 - Comment line(s) on [this file](src/providers/index.ts) to disable provider(s).
 
 - Run the `dev` script to start the server
+
 ```shell
 yarn dev
 ```

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -9,7 +9,11 @@ export default {
   collectCoverageFrom: ['./src/**'],
   coverageDirectory: 'coverage',
   coverageProvider: 'v8',
-  coveragePathIgnorePatterns: ['/node_modules/', '<rootDir>/dist/', '<rootDir>/test/fixtures/'],
+  coveragePathIgnorePatterns: [
+    '/node_modules/',
+    '<rootDir>/dist/',
+    '<rootDir>/test/fixtures/'
+  ],
   preset: 'ts-jest',
   testEnvironment: 'jest-environment-node-single-context',
   setupFiles: ['dotenv/config'],

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@snapshot-labs/eslint-config": "^0.1.0-beta.15",
-    "@snapshot-labs/prettier-config": "^0.1.0-beta.15",
+    "@snapshot-labs/prettier-config": "^0.1.0",
     "@types/express": "^4.17.11",
     "@types/jest": "^29.5.10",
     "@types/node": "^18.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1268,10 +1268,10 @@
   dependencies:
     "@snapshot-labs/eslint-config-base" "^0.1.0-beta.15"
 
-"@snapshot-labs/prettier-config@^0.1.0-beta.15":
-  version "0.1.0-beta.15"
-  resolved "https://registry.yarnpkg.com/@snapshot-labs/prettier-config/-/prettier-config-0.1.0-beta.15.tgz#07e5ae35ed36304250462218e115bab1c1609812"
-  integrity sha512-va6zYSl8oIraBJeIZWEatOI292rfJQouyyvEeHv8qi9ns+LgxMsKayQtXSqn9GcmAfdWQVs/P9bDaCQ77FyJYw==
+"@snapshot-labs/prettier-config@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@snapshot-labs/prettier-config/-/prettier-config-0.1.0.tgz#f0eafa4a3aed6a7fabaf88c016659f3343041071"
+  integrity sha512-8MYAHuewlAdJs55f94qQtEs/WLFmjgYfuIVb1iJPa9gUZauHEXMzbVpKZfnkQsgpwwcXxq9hzg0S/OeOkgj3+w==
 
 "@snapshot-labs/snapshot-metrics@^1.4.2":
   version "1.4.2"


### PR DESCRIPTION
Bumps `@snapshot-labs/prettier-config` from `^0.1.0-beta.15` to `^0.1.0`, which leaves Prettier's default `printWidth` of 80 (the `0.1.0` config sets no `printWidth`), and reflows the repo with `prettier --write`.

This is split out from the upcoming **ESLint 9 flat config migration** so that the formatting/reflow churn is isolated and easy to review on its own. The ESLint 9 PR is stacked on top of this branch and will contain only ESLint-related changes.

### Changes
- `@snapshot-labs/prettier-config` → `^0.1.0` (resolves to `0.1.0`, no `printWidth` → default 80)
- Regenerated `yarn.lock`
- `prettier --write` across the repo (minor reflow in `README.md`, `jest.config.ts`, `.github/dependabot.yml`; source files were already compliant)

### Validation (ESLint 8, unchanged on this branch)
- `yarn lint` ✅
- `yarn typecheck` ✅
- `yarn build` ✅
- `yarn test` ✅ (8 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)