### PR TITLE
chore(deps): bump @snapshot-labs/snapshot-metrics to 1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@ethersproject/wallet": "^5.7.0",
     "@pusher/push-notifications-server": "^1.2.5",
-    "@snapshot-labs/snapshot-metrics": "^1.4.3",
+    "@snapshot-labs/snapshot-metrics": "^1.5.0",
     "@snapshot-labs/snapshot-sentry": "^3.0.1",
     "@snapshot-labs/snapshot.js": "^0.14.26",
     "@xmtp/xmtp-js": "^10.2.0",

--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -19,6 +19,9 @@ new client.Gauge({
     const result = await db.queryAsync(
       `SELECT count(*) as count, event FROM events GROUP BY event`
     );
+    // Drop series for event types no longer present, otherwise a type that
+    // disappears from the table keeps reporting its last value forever.
+    this.reset();
     result.forEach(async function callback(this: any, data) {
       this.set({ type: data.event }, data.count);
     }, this);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1430,10 +1430,10 @@
   resolved "https://registry.yarnpkg.com/@snapshot-labs/prettier-config/-/prettier-config-0.1.0.tgz#f0eafa4a3aed6a7fabaf88c016659f3343041071"
   integrity sha512-8MYAHuewlAdJs55f94qQtEs/WLFmjgYfuIVb1iJPa9gUZauHEXMzbVpKZfnkQsgpwwcXxq9hzg0S/OeOkgj3+w==
 
-"@snapshot-labs/snapshot-metrics@^1.4.3":
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/@snapshot-labs/snapshot-metrics/-/snapshot-metrics-1.4.3.tgz#5d482dce48c8cdce828eb0543e97f0923bc70cbb"
-  integrity sha512-qbv2opVqKqYJApmt3UJuk4nBnGsrdMps2z+4WTQf7DzGVeecId3nRpBGCfv16TIZ5wuzw5qFNsczKCpLVc4lvw==
+"@snapshot-labs/snapshot-metrics@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@snapshot-labs/snapshot-metrics/-/snapshot-metrics-1.5.0.tgz#5b650e5d62fa9934c44771e688d6dfcaeb2090ee"
+  integrity sha512-wiWJWo72yZZ4Bq5hvFPCNCzWLJFpbZc86Wbr7UcR+CZqCVpQU6h++XGcekmeikygirhGiQkiFAnBw3y+fQ3AmQ==
   dependencies:
     express-prom-bundle "^6.6.0"
     node-fetch "^2.7.0"


### PR DESCRIPTION
Splits the metrics-package changes out of #292 so that PR stays a pure MySQL → Postgres migration.

## What changed in the package

`@snapshot-labs/snapshot-metrics` 1.4.3 → 1.5.0 is a single commit, [snapshot-labs/snapshot-metrics#24](https://github.com/snapshot-labs/snapshot-metrics/pull/24) "feat: add postgres pool instrumentation":

- adds `src/metrics/pg.ts`, exposing `pg_pool_max_connections_count`, `pg_pool_free_connections_count`, `pg_pool_all_connections_count` and `pg_pool_connections_queue_count` for a node-postgres pool;
- `init()` now picks the instrumentation by duck-typing the pool it is handed (`totalCount`/`idleCount` → pg, `_allConnections`/`config.connectionLimit` → mysql) instead of unconditionally calling the mysql one;
- a no-op refactor in `pushgateway.ts`. The `{ stop }` return value already existed in 1.4.3, so nothing about the call site changes.

That duck-typing is the only behavioural risk for this branch, since we still hand it a mysql pool. Verified against a real MariaDB 10.11 that the mysql branch is still selected and every `mysql_pool_*` gauge is unchanged — see below.

## Why this reduces churn in #292

#292 currently carries this bump (`package.json` + `yarn.lock`) inline. Landing it here means that when #292 rebases, its diff loses those lines and the metrics work left in it is purely the mysql → drizzle query rewrite.

The bump is a no-op on this branch, but it is a prerequisite for #292: without it, `init()` on 1.4.3 would hand a `pg.Pool` to the mysql instrumentation and blow up on `db.config.connectionLimit`.

## The `this.reset()` fix

This is the one behavioural change #292 was smuggling in, so it belongs on master rather than inside a migration PR. `events_per_type_count` never reset between collections, and prom-client retains every label series that was ever `set()`. An event type that ages out of the `events` table therefore keeps reporting its last value forever.

Note it is placed *after* the query rather than before it (as in #292), so there is no `await` between the `reset()` and the `set()` loop — otherwise a concurrent scrape and pushgateway push can serialise the gauge while it is empty.

## Verification

Real MariaDB 10.11, seeded `events`/`subscribers`/`subscriptions`/`xmtp`, the app's own `initMetrics()` on an express instance, scraping `/metrics`; then all rows of one event type are deleted and it is scraped again.

Before (1.4.3, master) — the deleted type is still reported:

```
===== SCRAPE 1 (all 4 event types present in db) =====
events_per_type_count{type="proposal/created"} 3
events_per_type_count{type="proposal/deleted"} 1
events_per_type_count{type="proposal/end"} 1
events_per_type_count{type="proposal/start"} 2
mysql_pool_acquiring_connections_count 2
mysql_pool_all_connections_count 2
mysql_pool_connections_queue_count 0
mysql_pool_free_connections_count 0
mysql_pool_max_connections_count 5

----- deleted all rows where event='proposal/deleted' (rows left: 0) -----

===== SCRAPE 2 (proposal/deleted no longer in db) =====
events_per_type_count{type="proposal/created"} 3
events_per_type_count{type="proposal/deleted"} 1     <-- stale
events_per_type_count{type="proposal/end"} 1
events_per_type_count{type="proposal/start"} 2
```

After (1.5.0 + `reset()`) — the series is dropped, and all five `mysql_pool_*` gauges are byte-identical:

```
===== SCRAPE 2 (proposal/deleted no longer in db) =====
events_per_type_count{type="proposal/created"} 3
events_per_type_count{type="proposal/end"} 1
events_per_type_count{type="proposal/start"} 2
mysql_pool_acquiring_connections_count 2
mysql_pool_all_connections_count 2
mysql_pool_connections_queue_count 0
mysql_pool_free_connections_count 0
mysql_pool_max_connections_count 5
```

Pool detection probed directly against the pool built by `src/helpers/mysql.ts`:

```
typeof db.totalCount      = undefined
typeof db.idleCount       = undefined
db._allConnections truthy = true (ctor: Array)
typeof db.config.connectionLimit = number = 5
--> 1.5.0 selects: MYSQL instrumentation
```

`yarn lint`, `yarn typecheck`, `yarn build` and `yarn test` all pass (4 tests, 1 suite).

Ref #292.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
