### PR TITLE
chore: stop collecting the xmtp subscriber count metric

### DIFF
--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -40,15 +40,8 @@ new client.Gauge({
       (await db.queryAsync(`SELECT count(*) as count FROM subscriptions`))[0]
         .count as any
     );
-    // XMTP provider is disabled in providers/index.ts
-    // this.set(
-    //   { type: 'xmtp' },
-    //   (
-    //     await db.queryAsync(
-    //       `SELECT count(*) as count FROM xmtp WHERE status = 1`
-    //     )
-    //   )[0].count as any
-    // );
+    // No xmtp count: the XMTP provider is disabled in providers/index.ts, so
+    // its subscriber table is neither read nor written.
   }
 });
 

--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -40,14 +40,15 @@ new client.Gauge({
       (await db.queryAsync(`SELECT count(*) as count FROM subscriptions`))[0]
         .count as any
     );
-    this.set(
-      { type: 'xmtp' },
-      (
-        await db.queryAsync(
-          `SELECT count(*) as count FROM xmtp WHERE status = 1`
-        )
-      )[0].count as any
-    );
+    // XMTP provider is disabled in providers/index.ts
+    // this.set(
+    //   { type: 'xmtp' },
+    //   (
+    //     await db.queryAsync(
+    //       `SELECT count(*) as count FROM xmtp WHERE status = 1`
+    //     )
+    //   )[0].count as any
+    // );
   }
 });
 


### PR DESCRIPTION
Pulls the XMTP metrics change out of #292 so that PR stays a pure MySQL → Postgres migration.

## What this does

`subscribers_per_type_count{type="xmtp"}` counts rows in the `xmtp` table. The XMTP provider has been commented out of [`src/providers/index.ts`](https://github.com/snapshot-labs/snapshot-webhook/blob/master/src/providers/index.ts) for a long time, so nothing reads or writes that table — the series reports a frozen number for a feature that is off. This stops collecting it.

The collection is deleted, with a short comment left in its place recording why `subscribers_per_type_count` carries no `xmtp` label (per review — the first revision of this PR commented the block out instead, which was the wrong call). #292 reaches the same runtime state by commenting the same block out (commit 2e40cc2, "drop unused xmtp_status_idx and comment out xmtp metrics count"), so whoever rebases #292 should resolve that hunk in favour of this deletion rather than restoring the commented-out lines.

## Why this reduces churn in #292

#292 currently carries this as a behavioural change buried inside a database migration — a reviewer of a MySQL → Postgres PR has to notice that a Prometheus series is being dropped along the way, and separately convince themselves nothing consumes it. Landing it here means #292's remaining metrics diff is purely the mysql → drizzle query rewrite.

Concretely, #292's commit 2e40cc2 touches `src/helpers/metrics.ts` in three ways: `this.reset()` on the events gauge (landed separately in #294), the xmtp comment-out (this PR), and the matching `eq` / `xmtp` import cleanup. Once #294 and this PR are on master, that whole hunk can drop out of 2e40cc2 on rebase.

To be accurate about what does *not* shrink: the `subscribers_per_type_count` hunk in #292 stays the same size, because the mysql → drizzle rewrite touches those lines either way, and it still conflicts on rebase. What changes is that both sides of that hunk now have xmtp commented out, so the hunk is mechanical and carries no behavioural delta.

## Consumers

This deletes a live series, so I checked for consumers before removing it:

- **Better Stack source `snapshot-webhook` (id 1338495)**: metrics catalog shows **0 ingested metrics**. The only entry is a `level` string label extracted from logs (15.9K data points, 1 active series). The source ingests logs only — no Prometheus series land there.
- **All 6 Better Stack dashboards** (Wan's, Chaitanya's, Digital Ocean's, Mana monitoring, SX Indexers, Onboarding) exported and inspected: none reference `subscribers_per_type_count`, and none query the webhook source at all.
- **All 6 Better Stack chart alerts**: all are on SX indexer, mana, or block-processing charts. None on webhook metrics.
- **GitHub code search across `org:snapshot-labs`** for `subscribers_per_type_count`: **1 hit total** — the definition in this file. No alerting rules, no dashboard-as-code, nothing in `ops-documentation`.

What I could not check: the app pushes to a Pushgateway configured purely by deploy-time env (`METRICS_PUSHGATEWAY_URL` / `METRICS_INSTANCE` / `METRICS_JOB_NAME` — none of them in this repo), so whatever Prometheus/Grafana sits downstream of that gateway is outside anything I can enumerate from the codebase. If someone has a Grafana panel or alert on this series, say so and I'll close this.

`xmtp_incoming_messages_count` is left alone — it is set by the provider itself, so with the provider disabled it is simply never emitted, and #292 leaves it alone too.

## Scope: `xmtp_status_idx` is deliberately not here

#292's 2e40cc2 also drops `xmtp_status_idx`. The equivalent on master is `INDEX status (status)` on the `xmtp` table in `src/helpers/schema.sql`. I left it out for three reasons:

1. It buys nothing. `schema.sql` is only applied by `yarn setup` against a fresh database — removing a line there does not drop the index on any deployed database.
2. It is not actually unused on master the way it is in #292's tree: `src/providers/xmtp.ts` still runs `SELECT address FROM xmtp WHERE status = 0`, which is exactly what that index serves. It is dead only because the provider is disabled.
3. It would make #292 *worse*, not better. #292 deletes `src/helpers/schema.sql` outright, so any edit to that file on master turns into a modify/delete conflict on rebase. Verified locally:

```
$ git rebase tmp-idx-sim          # 292 onto master + this PR + the schema.sql edit
CONFLICT (content): Merge conflict in src/helpers/metrics.ts
CONFLICT (modify/delete): src/helpers/schema.sql deleted in db18979 (refactor: migrate
database from mysql to postgres with drizzle) and modified in HEAD.
```

That second conflict does not appear when `schema.sql` is left untouched. The index drop belongs in #292, where it is one line of a generated migration.

## Verification

Local MariaDB 10.11 with master's `src/helpers/schema.sql` and seeded fixtures (`subscribers` 4 rows, `subscriptions` 2, `xmtp` 3 rows of which 2 have `status = 1`), booting the app's own `initMetrics()` on an express instance and scraping `/metrics`.

Before:

```
----- filtered /metrics -----
events_per_type_count{type="proposal/created"} 3
events_per_type_count{type="proposal/end"} 1
events_per_type_count{type="proposal/start"} 2
subscribers_per_type_count{type="discord"} 2
subscribers_per_type_count{type="http"} 4
subscribers_per_type_count{type="xmtp"} 2
----- end -----
raw db counts:
{"http":4,"discord":2,"xmtp":2}
```

After — the `xmtp` series is gone, `http` and `discord` are unchanged, and the database still holds the same 2 active xmtp rows, so this is the collector changing and not the data:

```
----- filtered /metrics -----
events_per_type_count{type="proposal/created"} 3
events_per_type_count{type="proposal/end"} 1
events_per_type_count{type="proposal/start"} 2
subscribers_per_type_count{type="discord"} 2
subscribers_per_type_count{type="http"} 4
----- end -----
raw db counts:
{"http":4,"discord":2,"xmtp":2}
```

`yarn lint`, `yarn typecheck`, `yarn test` (4 tests, 1 suite) and `yarn build` all pass.

Ref #292.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

