### PR TITLE
chore(deps): bump @snapshot-labs/snapshot-sentry to 3.1.0 and flush on crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@ethersproject/wallet": "^5.7.0",
     "@pusher/push-notifications-server": "^1.2.5",
     "@snapshot-labs/snapshot-metrics": "^1.5.0",
-    "@snapshot-labs/snapshot-sentry": "^3.0.1",
+    "@snapshot-labs/snapshot-sentry": "^3.1.0",
     "@snapshot-labs/snapshot.js": "^0.14.26",
     "@xmtp/xmtp-js": "^10.2.0",
     "bluebird": "^3.7.2",

--- a/src/replay.ts
+++ b/src/replay.ts
@@ -1,4 +1,4 @@
-import { capture } from '@snapshot-labs/snapshot-sentry';
+import { capture, Sentry } from '@snapshot-labs/snapshot-sentry';
 import snapshot from '@snapshot-labs/snapshot.js';
 import { EnumType } from 'json-to-graphql-query';
 import { handleCreatedEvent, handleDeletedEvent } from './events';
@@ -101,7 +101,9 @@ export async function run() {
       }
       await snapshot.utils.sleep(10e3);
     } catch (err) {
+      console.error(err);
       capture(err);
+      await Sentry.close(2000);
       // CRASH THE ENTIRE SERVER
       process.exit(1);
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1439,10 +1439,10 @@
     node-fetch "^2.7.0"
     prom-client "^14.2.0"
 
-"@snapshot-labs/snapshot-sentry@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@snapshot-labs/snapshot-sentry/-/snapshot-sentry-3.0.1.tgz#e9c6e43b1a592e02c6d41fc769e0ca4e34dda9b7"
-  integrity sha512-SURO5JZA5k64Qxe5iUVUOjpxNyRcdwj+sP0UrxlMLXXqtf4yRAm91fFKHnn0AhO1F757ldrt3faZVSftcCRASQ==
+"@snapshot-labs/snapshot-sentry@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@snapshot-labs/snapshot-sentry/-/snapshot-sentry-3.1.0.tgz#9e9c306ea6e32025d6c902fbe45e7e882dbde2a3"
+  integrity sha512-MIIQyW0GZisXa93JvDWFdMO0Ycu9JXBH0P3ca0qJ7HhbxfNrzqLOr1dzhKdhXT0e+sTWO7UCxdeQTGF3dV0l7w==
   dependencies:
     "@sentry/node" "^10.52.0"
 


### PR DESCRIPTION
Extracted from #292 (mysql → postgres migration), as suggested there — the Sentry package bump and the `Sentry.*()` call site it enables have nothing to do with the migration.

## What the bump is

`@snapshot-labs/snapshot-sentry` `^3.0.1` → `^3.1.0`.

3.1.0 was published 2026-07-27. Diffed the two tarballs; the entire change to `src/index.ts` is one line:

```diff
 import * as Sentry from '@sentry/node';
 import { Express } from 'express';

+export { Sentry };
```

Changelog entry:

> **v3.1.0** — re-export the `Sentry` namespace from `@sentry/node`, so consumers can call `Sentry.flush()` / `Sentry.close()` (e.g. for graceful shutdown) without installing `@sentry/node` themselves

Nothing else moved:

* No existing export changed signature or behaviour. `capture`, `initLogger`, `fallbackLogger`, `scrubData`, `sensitiveDataToScrub`, `normalizedError`, `normalizedCaptureContext` are byte-identical.
* The dependency set is unchanged (`@sentry/node "^10.52.0"` in both), and the transitive resolution in `yarn.lock` is unchanged too — `@sentry/node` stays on 10.62.0 before and after. The `yarn.lock` diff here is only the four lines of the `snapshot-sentry` entry itself.
* No breaking changes. The last breaking change in this package was 3.0.0 (Node >= 20.19), which this repo already ships (`engines.node: ">=22.6.0"`, CI on Node 22).

It is **not** cosmetic — it is a hard prerequisite for the call site below, same as the metrics bump in #294 turned out to be. On 3.0.1 the import does not compile:

```
$ yarn typecheck   # with 3.0.1 force-installed
src/replay.ts(1,19): error TS2459: Module '"@snapshot-labs/snapshot-sentry"' declares 'Sentry' locally, but it is not exported.
```

## The call site that moved

`src/replay.ts`, the fatal catch in `run()`:

```diff
     } catch (err) {
+      console.error(err);
       capture(err);
+      await Sentry.close(2000);
       // CRASH THE ENTIRE SERVER
       process.exit(1);
     }
```

`capture()` is fire-and-forget: it queues the event on the async transport and returns. The `process.exit(1)` two lines down tears the process down before the envelope reaches the socket. So the single error that takes the whole service out is precisely the one that never arrives in Sentry — and because this path also never logged, it currently crashes while printing nothing at all.

`Sentry.close(2000)` flushes with a 2s deadline first. `close` rather than `flush` because we exit immediately after and never want the client again.

### Demonstrated against a local Sentry ingest

Stood up a small HTTP sink in place of Sentry ingest, pointed `SENTRY_DSN` at it, and drove the **real** `replay.run()` loop (real `initLogger()` from `src/instrument.ts`, real mysql pool) against a dead database so the real catch block fires. Master's `src/replay.ts` and this branch's, three runs each:

```
variant=master  exit=1 error_envelopes_delivered=0
variant=patched exit=1 error_envelopes_delivered=1
variant=master  exit=1 error_envelopes_delivered=0
variant=patched exit=1 error_envelopes_delivered=1
variant=master  exit=1 error_envelopes_delivered=0
variant=patched exit=1 error_envelopes_delivered=1
```

Deterministic, not a race. The envelope that now arrives:

```
item header     : {"type": "event"}
level           : error
exception.type  : Error
exception.value : connect ECONNREFUSED 127.0.0.1:3399
mechanism       : {"type": "generic", "handled": true}
```

## Deliberately left in #292

Two `Sentry` call sites from #292 are **not** here, because they do not apply to master's pre-migration code:

1. **`src/db.ts` — `db.$client.on('error', err => capture(err))`.** `src/db.ts` is created by #292; this is a listener on the `pg` `Pool`, guarding against an unhandled EventEmitter `'error'` on an idle pooled client. Master has `src/helpers/mysql.ts` on the `mysql` driver, which has no equivalent handle. It belongs with the drizzle/`pg` change.

2. **`src/index.ts` — `start().catch(err => { capture(err); await Sentry.close(2000); ... })`.** That handler exists only because #292 wraps the bootstrap in an `async start()` in order to `await runMigrations()`. Master listens at module top level and has no `start()` to attach a catch to. Without the migration there is nothing for it to guard.

Separately noted, not changed here since it is not in #292: master's `gracefulShutdown` catch in `src/index.ts` does `console.error` + `process.exit(1)` with no `capture()` at all. Worth a follow-up, but out of scope for an extraction.

## Effect on #292

Removes 14 changed lines (8 additions, 6 deletions) across `package.json`, `yarn.lock` and `src/replay.ts` once #292 rebases on master. Small in line count, but it takes an entire dependency bump — a change class reviewers have to vet on its own terms — out of a 1559/418 migration diff, and leaves the `src/replay.ts` hunk there as purely the mysql → drizzle rewrite.

Every one of the 14 lines is verbatim from #292; nothing was rewritten in the move.

## Gates

Run in order (`yarn test` before `yarn build` — the coverage worker exits 1 if `dist/` is present, which is pre-existing on master and unrelated to this change; `dist/` cleaned afterwards).

```
$ yarn lint
$ eslint .
Done in 6.80s.                                    → exit 0

$ yarn typecheck
$ tsc --noEmit
Done in 9.35s.                                    → exit 0

$ yarn test
Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
Done in 17.56s.                                   → exit 0

$ yarn build
$ tsc
Done in 11.59s.                                   → exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
