### PR TITLE
perf(webhook): filter subscribers by space in SQL

### DIFF
--- a/src/providers/webhook.ts
+++ b/src/providers/webhook.ts
@@ -46,14 +46,15 @@ export async function sendEvent(event, to, method = 'POST') {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export async function send(event, _proposal, _subscribersAddresses) {
   const subscribers = await db.queryAsync(
-    'SELECT * FROM subscribers WHERE active = 1'
+    'SELECT url, method FROM subscribers WHERE active = 1 AND space IN (?)',
+    [[event.space, '*']]
   );
-  console.log('[webhook] subscribers', subscribers.length);
+  console.log('[webhook] subscribers for', event.space, subscribers.length);
 
   Promise.allSettled(
-    subscribers
-      .filter(subscriber => [event.space, '*'].includes(subscriber.space))
-      .map(subscriber => sendEvent(event, subscriber.url, subscriber.method))
+    subscribers.map(subscriber =>
+      sendEvent(event, subscriber.url, subscriber.method)
+    )
   )
     .then(() => console.log('[webhook] process event done'))
     .catch(e => capture(e));

--- a/src/providers/webhook.ts
+++ b/src/providers/webhook.ts
@@ -45,14 +45,9 @@ export async function sendEvent(event, to, method = 'POST') {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export async function send(event, _proposal, _subscribersAddresses) {
-  // The indexed SQL predicate narrows 'every active row' down to a small
-  // candidate set, but it matches under the column collation
-  // (utf8mb4_general_ci: case-insensitive, accent-insensitive, PAD SPACE), so
-  // it can also return rows whose space is not byte-identical to the event's
-  // -- 'FOO.ETH', 'fóo.eth' and 'foo.eth ' all match an event for 'foo.eth'.
-  // Re-apply the exact JS comparison to the candidates so the set we actually
-  // send to stays identical to a plain equality filter. Collating the column
-  // in SQL instead would defeat the index this query relies on.
+  // utf8mb4_general_ci makes the SQL predicate case-, accent- and
+  // trailing-space-insensitive, so the JS filter keeps the match exact.
+  // Collating the column in SQL instead would drop the index.
   const candidates = await db.queryAsync(
     'SELECT space, url, method FROM subscribers WHERE active = 1 AND space IN (?)',
     [[event.space, '*']]

--- a/src/providers/webhook.ts
+++ b/src/providers/webhook.ts
@@ -45,9 +45,20 @@ export async function sendEvent(event, to, method = 'POST') {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export async function send(event, _proposal, _subscribersAddresses) {
-  const subscribers = await db.queryAsync(
-    'SELECT url, method FROM subscribers WHERE active = 1 AND space IN (?)',
+  // The indexed SQL predicate narrows 'every active row' down to a small
+  // candidate set, but it matches under the column collation
+  // (utf8mb4_general_ci: case-insensitive, accent-insensitive, PAD SPACE), so
+  // it can also return rows whose space is not byte-identical to the event's
+  // -- 'FOO.ETH', 'fóo.eth' and 'foo.eth ' all match an event for 'foo.eth'.
+  // Re-apply the exact JS comparison to the candidates so the set we actually
+  // send to stays identical to a plain equality filter. Collating the column
+  // in SQL instead would defeat the index this query relies on.
+  const candidates = await db.queryAsync(
+    'SELECT space, url, method FROM subscribers WHERE active = 1 AND space IN (?)',
     [[event.space, '*']]
+  );
+  const subscribers = candidates.filter(subscriber =>
+    [event.space, '*'].includes(subscriber.space)
   );
   console.log('[webhook] subscribers for', event.space, subscribers.length);
 

--- a/test/unit/providers/webhook.test.ts
+++ b/test/unit/providers/webhook.test.ts
@@ -35,10 +35,7 @@ const EVENT = {
   expire: 1647343155
 };
 
-// Lets the fire-and-forget Promise.allSettled inside send() settle.
 const flush = () => new Promise(resolve => setImmediate(resolve));
-
-// Returns the URLs that actually received a webhook.
 const deliveredUrls = () => mockFetch.mock.calls.map(call => call[0]).sort();
 
 beforeEach(() => {
@@ -75,11 +72,6 @@ describe('webhook provider', () => {
       ]);
     });
 
-    // The SQL predicate matches under the column collation
-    // (utf8mb4_general_ci), which is case-insensitive, accent-insensitive and
-    // PAD SPACE. Each of the rows below is really returned by
-    // `space IN ('foo.eth', '*')` but is not byte-identical to the event's
-    // space, so none of them may receive the webhook.
     it.each([
       ['an upper-case variant', 'FOO.ETH'],
       ['a mixed-case variant', 'Foo.Eth'],

--- a/test/unit/providers/webhook.test.ts
+++ b/test/unit/providers/webhook.test.ts
@@ -1,0 +1,149 @@
+import { timeOutgoingRequest } from '../../../src/helpers/metrics';
+import { send } from '../../../src/providers/webhook';
+
+const mockQueryAsync = jest.fn();
+jest.mock('../../../src/helpers/mysql', () => ({
+  __esModule: true,
+  default: {
+    queryAsync: (...args: any[]) => mockQueryAsync(...args)
+  }
+}));
+
+const mockFetch = jest.fn();
+jest.mock('@snapshot-labs/snapshot.js', () => {
+  const originalModule = jest.requireActual('@snapshot-labs/snapshot.js');
+
+  return {
+    ...originalModule,
+    utils: {
+      ...originalModule.utils,
+      fetch: (...args: any[]) => mockFetch(...args)
+    }
+  };
+});
+
+jest.mock('../../../src/helpers/metrics', () => ({
+  __esModule: true,
+  outgoingMessages: { inc: jest.fn() },
+  timeOutgoingRequest: { startTimer: jest.fn() }
+}));
+
+const EVENT = {
+  id: 'proposal/0xabc',
+  space: 'foo.eth',
+  event: 'proposal/created',
+  expire: 1647343155
+};
+
+// Lets the fire-and-forget Promise.allSettled inside send() settle.
+const flush = () => new Promise(resolve => setImmediate(resolve));
+
+// Returns the URLs that actually received a webhook.
+const deliveredUrls = () => mockFetch.mock.calls.map(call => call[0]).sort();
+
+beforeEach(() => {
+  (timeOutgoingRequest.startTimer as jest.Mock).mockReturnValue(jest.fn());
+  mockFetch.mockResolvedValue({ status: 200 });
+  jest.spyOn(console, 'log').mockImplementation(() => undefined);
+});
+
+describe('webhook provider', () => {
+  describe('send()', () => {
+    it('filters on the indexed space column in SQL', async () => {
+      mockQueryAsync.mockResolvedValueOnce([]);
+
+      await send(EVENT, null, []);
+
+      expect(mockQueryAsync).toHaveBeenCalledWith(
+        'SELECT space, url, method FROM subscribers WHERE active = 1 AND space IN (?)',
+        [['foo.eth', '*']]
+      );
+    });
+
+    it('sends to subscribers of the event space and to wildcard subscribers', async () => {
+      mockQueryAsync.mockResolvedValueOnce([
+        { space: 'foo.eth', url: 'https://exact.test', method: 'POST' },
+        { space: '*', url: 'https://wildcard.test', method: 'POST' }
+      ]);
+
+      await send(EVENT, null, []);
+      await flush();
+
+      expect(deliveredUrls()).toEqual([
+        'https://exact.test',
+        'https://wildcard.test'
+      ]);
+    });
+
+    // The SQL predicate matches under the column collation
+    // (utf8mb4_general_ci), which is case-insensitive, accent-insensitive and
+    // PAD SPACE. Each of the rows below is really returned by
+    // `space IN ('foo.eth', '*')` but is not byte-identical to the event's
+    // space, so none of them may receive the webhook.
+    it.each([
+      ['an upper-case variant', 'FOO.ETH'],
+      ['a mixed-case variant', 'Foo.Eth'],
+      ['an accented variant', 'fóo.eth'],
+      ['a trailing-space variant', 'foo.eth ']
+    ])('does not send to %s of the event space', async (_label, space) => {
+      mockQueryAsync.mockResolvedValueOnce([
+        { space, url: 'https://variant.test', method: 'POST' }
+      ]);
+
+      await send(EVENT, null, []);
+      await flush();
+
+      expect(deliveredUrls()).toEqual([]);
+    });
+
+    it('keeps the exact match when collation variants are returned alongside it', async () => {
+      mockQueryAsync.mockResolvedValueOnce([
+        { space: 'foo.eth', url: 'https://exact.test', method: 'POST' },
+        { space: 'FOO.ETH', url: 'https://upper.test', method: 'POST' },
+        { space: 'Foo.Eth', url: 'https://mixed.test', method: 'POST' },
+        { space: 'fóo.eth', url: 'https://accent.test', method: 'POST' },
+        { space: 'foo.eth ', url: 'https://trailing.test', method: 'POST' },
+        { space: '*', url: 'https://wildcard.test', method: 'POST' }
+      ]);
+
+      await send(EVENT, null, []);
+      await flush();
+
+      expect(deliveredUrls()).toEqual([
+        'https://exact.test',
+        'https://wildcard.test'
+      ]);
+    });
+
+    it('logs the number of subscribers actually sent to, not the candidate count', async () => {
+      mockQueryAsync.mockResolvedValueOnce([
+        { space: 'foo.eth', url: 'https://exact.test', method: 'POST' },
+        { space: 'FOO.ETH', url: 'https://upper.test', method: 'POST' },
+        { space: 'foo.eth ', url: 'https://trailing.test', method: 'POST' }
+      ]);
+
+      await send(EVENT, null, []);
+      await flush();
+
+      expect(console.log).toHaveBeenCalledWith(
+        '[webhook] subscribers for',
+        'foo.eth',
+        1
+      );
+    });
+
+    it('uses the method stored on the subscriber', async () => {
+      mockQueryAsync.mockResolvedValueOnce([
+        { space: 'foo.eth', url: 'https://get.test', method: 'GET' }
+      ]);
+
+      await send(EVENT, null, []);
+      await flush();
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://get.test',
+        expect.objectContaining({ method: 'GET' })
+      );
+    });
+  });
+});


### PR DESCRIPTION
Extracted from #292 so it can be reviewed on its own. Nothing else from that PR is included here.

## The problem

`send()` in `src/providers/webhook.ts` loads **every active subscriber row in the table** and then narrows it down to the event's space in JS:

```ts
const subscribers = await db.queryAsync(
  'SELECT * FROM subscribers WHERE active = 1'
);
...
subscribers.filter(subscriber => [event.space, '*'].includes(subscriber.space))
```

That runs once per webhook event, and it is a full table scan every time.

## The change

Push the predicate into SQL so the lookup uses the `space` index, then keep the original exact comparison over the small candidate set that comes back:

```ts
const candidates = await db.queryAsync(
  'SELECT space, url, method FROM subscribers WHERE active = 1 AND space IN (?)',
  [[event.space, '*']]
);
const subscribers = candidates.filter(subscriber =>
  [event.space, '*'].includes(subscriber.space)
);
```

`schema.sql` already has `INDEX space (space)`, so **no schema change is needed**.

The log line now includes the space, because the count it prints no longer means "all active subscribers" — without that it would silently start reporting a different number.

### Why the JS filter is still there

The first version of this PR dropped it and matched purely in SQL. That was wrong, and @chai3-bot caught it in review. `space` is `VARCHAR(256)` with no explicit collation, so it inherits `utf8mb4_general_ci`, which is case-insensitive, accent-insensitive and PAD SPACE. The SQL predicate alone therefore matches rows the old JS filter rejected. Reproduced on the seeded table — an event for `foo.eth` selects five rows where the JS filter accepts one:

```
url                            space         HEX(space)
https://probe.test/exact       [foo.eth]     666F6F2E657468
https://probe.test/upper       [FOO.ETH]     464F4F2E455448
https://probe.test/mixed       [Foo.Eth]     466F6F2E457468
https://probe.test/accent      [fóo.eth]     66C3B36F2E657468
https://probe.test/trailing    [foo.eth ]    666F6F2E65746820
```

Re-applying the byte-exact JS comparison to the candidate set makes the sent-to set equal to master's by construction, whatever the collation does. Coercing the column in SQL instead would have fixed the semantics but removed the index — the whole point of the change:

```
WHERE active = 1 AND space IN ('foo.eth','*')                      type=range key=space rows=20
WHERE active = 1 AND BINARY space IN ('foo.eth','*')               type=ALL   key=NULL  rows=297397
WHERE active = 1 AND space COLLATE utf8mb4_bin IN ('foo.eth','*')  type=ALL   key=NULL  rows=297397
```

Accent-insensitivity applies to precomposed characters only (`fóo.eth` with U+00F3 matches; the decomposed `o` + U+0301 form does not), and PAD SPACE ignores trailing whitespace only (`' foo.eth'` is correctly excluded).

## Measurements

Local MariaDB `10.11.14`, table seeded to **300,000 subscribers, 270,000 active (90%), 5,001 distinct spaces** including 15 active `*` wildcard rows, plus the collation probe rows above. Both variants driven through the same `mysql` pool the app uses (`src/helpers/mysql.ts`: bluebird-promisified, `connectionLimit: 5`), 40 lookups each over the 40 largest spaces (~57 subscribers each), warm-up discarded, and the order alternated each iteration so neither variant gets a systematic cache advantage.

```
latency over 40 lookups (query + JS filter):
  master   median 711.4 ms   min 636.3   p95 827.5   max 831.4   mean 716.3
  patched  median 1.4 ms     min 0.9     p95 4.9     max 5.3     mean 1.7
  speedup (median): 492.8x

rows shipped from MySQL to node:
  master  10800280 rows total (270007/lookup)
  patched 2885 rows total (72.1/lookup)

result sets vs master: 40/40 identical, 0 mismatches
```

A second run gave 469.3x (master 724.6 ms, patched 1.5 ms). The extra `space` column and the JS pass cost nothing measurable.

The box is noisy at this row count and its load varies between sittings — an earlier write-up of this PR measured the master median at 1.3–2.3 s on the same table and same harness. Read the master figure as "hundreds of ms to seconds", not as a precise number. What does not move between runs is the shape: a full scan of 270k rows versus a range scan returning ~72.

### EXPLAIN

Before:

```
id  select_type  table        type  possible_keys  key   key_len  ref   rows    Extra
1   SIMPLE       subscribers  ALL   active         NULL  NULL     NULL  297397  Using where
```

After:

```
id  select_type  table        type   possible_keys  key    key_len  ref   rows  Extra
1   SIMPLE       subscribers  range  space,active   space  1026     NULL  20    Using index condition; Using where
```

## Correctness

Checked rather than argued. For each lookup the driver ran both implementations and compared the sorted `(url, method)` set:

- 40/40 probe spaces produced **identical, non-empty** result sets.
- The collation variants above: master matches 1, this PR matches 1, identical. (The first version of this PR matched 5.)
- `event.space` with no subscribers at all: both return the 15 active `*` rows, identical.
- `event.space === '*'`: both return 15, identical.
- A space that also has inactive rows: both return 67, identical — the `active = 1` predicate still excludes them.

The `space IN (?)` array expansion is the standard `mysql` driver nested-array form and escapes to `space in ('space1234.eth','*')`, visible in the `index_condition` above.

## Tests

`test/unit/providers/webhook.test.ts` is new — this provider had no tests, so the query had no regression guard. Nine cases covering the exact match, the `*` wildcard, and the case, accent and trailing-space variants, asserting on the URLs that actually receive a webhook. Coverage of `src/providers/webhook.ts` goes 0% → 90.27%.

The first case asserts the SQL string and its params, so the predicate cannot quietly regress to a full scan later.

Verified non-vacuous: reverting only the source change turns 7 of the 9 red, including all four variant cases.

## Gates

```
$ yarn lint       Done in 2.83s.   exit 0
$ yarn typecheck  Done in 4.12s.   exit 0
$ yarn test       Test Suites: 2 passed, 2 total / Tests: 13 passed, 13 total   exit 0
$ yarn build      Done in 5.06s.   exit 0
```

(`yarn test` was run before `yarn build`, since it exits 1 when `dist/` exists; `dist/` was removed afterwards.)

## Why separately

#292 bundles this together with unrelated changes. Landing it on its own removes it from that diff and keeps the perf claim reviewable against a single file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
