### PR TITLE
fix(utils): fetch proposal created timestamp in getProposal

### DIFF
--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -53,6 +53,7 @@ export async function getProposal(
       title: true,
       body: true,
       choices: true,
+      created: true,
       start: true,
       end: true,
       link: true,


### PR DESCRIPTION
Extracted from #292 so it can be reviewed on its own. One line.

## The bug

`handleCreatedEvent()` in `src/events.ts` schedules the `proposal/created` event using the proposal's creation time:

```ts
params = [{ event: 'proposal/created', expire: proposal.created, ...proposalEvent }];
```

But `getProposal()` in `src/helpers/utils.ts` never asked the hub for `created`. The GraphQL selection set has `title`, `body`, `choices`, `start`, `end`, `link`, `snapshot`, `flagged` — no `created`. So `proposal.created` is always `undefined`.

Verified against the live hub (`https://hub.snapshot.org`), calling each branch's own `getProposal()` on three real proposals:

```
===== master (unpatched getProposal) =====
0x164ea3e39e  space=hogeinc.eth      'created' in proposal = false  created=undefined (undefined)  start=1785249197
0xd39a47645b  space=pikudao.eth      'created' in proposal = false  created=undefined (undefined)  start=1785248096
0xb9ec5ea92d  space=anoma.eth        'created' in proposal = false  created=undefined (undefined)  start=1785240564

===== patched (created: true) =====
0x164ea3e39e  space=hogeinc.eth      'created' in proposal = true   created=1785249197 (number)   start=1785249197
0xd39a47645b  space=pikudao.eth      'created' in proposal = true   created=1785248096 (number)   start=1785248096
0xb9ec5ea92d  space=anoma.eth        'created' in proposal = true   created=1785240564 (number)   start=1785240564
```

Note the key is not merely `undefined`, it is **absent** from the object — the hub was never asked.

## What that does downstream

`events.expire` is `INT(11) NOT NULL` (`src/helpers/schema.sql`). The `mysql` driver serialises `undefined` as `NULL`. And the statement is an `INSERT IGNORE`, which downgrades the resulting error 1048 to a warning and stores the implicit default, `0`.

Reproduced against a local MariaDB with the real `events` schema, `sql_mode = IGNORE_SPACE,STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION`, running the exact statement `handleCreatedEvent()` builds:

```
master  (created undefined)  SQL sent -> INSERT IGNORE INTO events SET `event` = 'proposal/created', `expire` = NULL, `id` = ..., `space` = 'test.eth';
master  (created undefined)  warnings: [{"Level":"Warning","Code":1048,"Message":"Column 'expire' cannot be null"}]
patched (created number)     SQL sent -> INSERT IGNORE INTO events SET `event` = 'proposal/created', `expire` = 1785249197, `id` = ..., `space` = 'test.eth';
patched (created number)     warnings: none

stored rows:
  master  (created undefined)   expire = 0
  patched (created number)      expire = 1785249197
```

So every `proposal/created` row ever written has carried `expire = 0` rather than the proposal's creation time. Note that `STRICT_TRANS_TABLES` is on and it still goes through — `INSERT IGNORE` is the only reason this has not been throwing.

Two consequences:

1. **A `NULL` is being written into a `NOT NULL` column and only survives because of `INSERT IGNORE`.** Anything that tightens that path turns a silent warning into a hard failure that drops the event. The same `expire: proposal.created` line is carried over unchanged onto the in-flight Postgres migration branch (`fix/migrate-postgresql`), where the insert becomes `db.insert(events).values(rows).onConflictDoNothing()` — and `ON CONFLICT DO NOTHING` suppresses conflict violations, not `NOT NULL` violations. Better to have this fixed before that lands.
2. **`events.expire` carries no information for `proposal/created` rows.** `processEvents()` selects `WHERE expire <= ?`, so an `expire` of `0` is unconditionally due on the next sweep regardless of the `DELAY` the code intends, and the column cannot be used to reason about, order, or backfill these rows.

The user-visible symptom is mild today — `created` is approximately "now" when the replay loop picks the proposal up, so the event still goes out promptly — which is exactly why this has gone unnoticed. The stored data is wrong either way.

## The fix

```diff
       choices: true,
+      created: true,
       start: true,
```

## Gates

```
$ yarn lint       Done in 3.41s.   exit 0
$ yarn typecheck  Done in 5.52s.   exit 0
$ yarn test       Test Suites: 1 passed, 1 total / Tests: 4 passed, 4 total   exit 0
$ yarn build      Done in 4.69s.   exit 0
```

(`yarn test` was run before `yarn build`, since it exits 1 when `dist/` exists; `dist/` was removed afterwards.)

## Why separately

Pulled out of #292, which bundles it with unrelated changes. It is a one-line bug fix and does not need to wait on the rest of that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
