### PR TITLE
fix: stop background workers and metrics on graceful shutdown

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -8,7 +8,10 @@ import { events } from './schema';
 
 const DELAY = 10;
 const INTERVAL = 15;
-const SERVICE_EVENTS = parseInt(process.env.SERVICE_EVENTS || '0');
+
+let timer: NodeJS.Timeout | undefined;
+let running: Promise<void> | undefined;
+let stopped = false;
 
 export async function handleCreatedEvent(event) {
   const { space, id } = event;
@@ -70,6 +73,8 @@ async function processEvents() {
   console.log('[events] Process event start', ts, expiredEvents.length);
 
   for (const event of expiredEvents) {
+    if (stopped) break;
+
     const proposalId = event.id.replace('proposal/', '');
     let proposal;
     if (event.event === 'proposal/deleted') {
@@ -79,9 +84,9 @@ async function processEvents() {
     }
     if (proposal) {
       const subscribers = await getSubscribers(event.space);
-      providers.forEach(provider => {
-        provider(event, proposal, subscribers);
-      });
+      await Promise.allSettled(
+        providers.map(provider => provider(event, proposal, subscribers))
+      );
     } else {
       console.log(`[events] Proposal ${proposalId} not found`);
     }
@@ -99,20 +104,23 @@ async function processEvents() {
 }
 
 async function run() {
-  while (true) {
-    try {
-      await processEvents();
-    } catch (err) {
-      capture(err);
-      console.log('[events] Failed to process', err);
-    } finally {
-      await snapshot.utils.sleep(INTERVAL * 1e3);
-    }
-  }
+  running = processEvents().catch(err => {
+    capture(err);
+    console.log('[events] Failed to process', err);
+  });
+  await running;
+
+  if (!stopped) timer = setTimeout(run, INTERVAL * 1e3);
 }
 
 export function start() {
-  if (SERVICE_EVENTS) {
-    setTimeout(() => run(), INTERVAL * 1e3);
-  }
+  stopped = false;
+  timer = setTimeout(run, INTERVAL * 1e3);
+}
+
+export async function stop() {
+  stopped = true;
+  clearTimeout(timer);
+  await running;
+  console.log('[events] Loop stopped');
 }

--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -5,29 +5,50 @@ import { Express } from 'express';
 import { db } from '../db';
 import { events, subscribers, subscriptions } from '../schema';
 
+const activeDatabaseCollections = new Set<Promise<void>>();
+
+async function trackDatabaseCollection(collect: () => Promise<void>) {
+  const running = collect();
+  activeDatabaseCollections.add(running);
+  try {
+    await running;
+  } finally {
+    activeDatabaseCollections.delete(running);
+  }
+}
+
 export default function initMetrics(app: Express) {
-  return init(app, {
+  const metrics = init(app, {
     whitelistedPath: [/^\/$/, /^\/api\/test$/],
     errorHandler: capture,
     db: db.$client
   });
+
+  return {
+    async stop() {
+      metrics.stop();
+      await Promise.allSettled(activeDatabaseCollections);
+    }
+  };
 }
 
 new client.Gauge({
   name: 'events_per_type_count',
   help: 'Number of events per type',
   labelNames: ['type'],
-  async collect() {
-    // Drop series for event types no longer present, otherwise a type that
-    // disappears from the table keeps reporting its last value forever.
-    this.reset();
-    const results = await db
-      .select({ event: events.event, count: count() })
-      .from(events)
-      .groupBy(events.event);
+  collect() {
+    return trackDatabaseCollection(async () => {
+      // Drop series for event types no longer present, otherwise a type that
+      // disappears from the table keeps reporting its last value forever.
+      this.reset();
+      const results = await db
+        .select({ event: events.event, count: count() })
+        .from(events)
+        .groupBy(events.event);
 
-    results.forEach(result => {
-      this.set({ type: result.event }, result.count);
+      results.forEach(result => {
+        this.set({ type: result.event }, result.count);
+      });
     });
   }
 });
@@ -36,15 +57,17 @@ new client.Gauge({
   name: 'subscribers_per_type_count',
   help: 'Number of subscribers per type',
   labelNames: ['type'],
-  async collect() {
-    const [http, discord] = await Promise.all([
-      db.$count(subscribers),
-      db.$count(subscriptions)
-    ]);
-    this.set({ type: 'http' }, http);
-    this.set({ type: 'discord' }, discord);
-    // No xmtp count: the XMTP provider is disabled in providers/index.ts, so
-    // its subscriber table is neither read nor written.
+  collect() {
+    return trackDatabaseCollection(async () => {
+      const [http, discord] = await Promise.all([
+        db.$count(subscribers),
+        db.$count(subscriptions)
+      ]);
+      this.set({ type: 'http' }, http);
+      this.set({ type: 'discord' }, discord);
+      // No xmtp count: the XMTP provider is disabled in providers/index.ts, so
+      // its subscriber table is neither read nor written.
+    });
   }
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,12 +11,18 @@ import express from 'express';
 import api from './api';
 import pkg from '../package.json';
 import { closeDatabase, runMigrations } from './db';
-import { start as startEvents } from './events';
+import { start as startEvents, stop as stopEvents } from './events';
 import initMetrics from './helpers/metrics';
-import { last_mci, run } from './replay';
+import {
+  start as startDiscord,
+  stop as stopDiscord
+} from './providers/discord';
+import { last_mci, start as startReplay, stop as stopReplay } from './replay';
 
 const app = express();
 const PORT = process.env.PORT || 3000;
+const SERVICE_EVENTS = parseInt(process.env.SERVICE_EVENTS || '0');
+const SHUTDOWN_TIMEOUT = 25000;
 
 const { stop: stopMetrics } = initMetrics(app);
 
@@ -47,39 +53,80 @@ app.use((_, res) => {
   });
 });
 
+let server: ReturnType<typeof app.listen> | undefined;
+let shuttingDown = false;
+let fatalExitStarted = false;
+
+async function fatal(err: unknown) {
+  if (fatalExitStarted) return;
+  fatalExitStarted = true;
+
+  console.error(err);
+  try {
+    capture(err);
+    await Sentry.close(2000);
+  } finally {
+    process.exit(1);
+  }
+}
+
+const closeServer = () =>
+  new Promise<void>((resolve, reject) => {
+    if (!server) return resolve();
+
+    server.close(err => {
+      if (err) return reject(err);
+      console.log('Express server closed.');
+      resolve();
+    });
+  });
+
+async function gracefulShutdown(signal: string) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+
+  const forceExit = setTimeout(
+    () => fatal(new Error('Could not shut down in time, forcefully exiting')),
+    SHUTDOWN_TIMEOUT
+  ).unref();
+
+  console.log(`Received ${signal}. Starting graceful shutdown...`);
+
+  const metricsStopped = stopMetrics();
+
+  try {
+    await Promise.all([
+      closeServer(),
+      stopReplay(),
+      stopEvents(),
+      metricsStopped
+    ]);
+    await stopDiscord();
+
+    await closeDatabase();
+    clearTimeout(forceExit);
+    if (fatalExitStarted) return;
+    console.log('Graceful shutdown completed.');
+    process.exit(0);
+  } catch (err) {
+    clearTimeout(forceExit);
+    await fatal(err);
+  }
+}
+
+process.on('SIGINT', () => gracefulShutdown('SIGINT'));
+process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));
+
 async function start() {
   await runMigrations();
-  run();
-  startEvents();
-  const server = app.listen(PORT, () =>
+
+  server = app.listen(PORT, () =>
     console.log(`Listening at http://localhost:${PORT}`)
   );
 
-  const gracefulShutdown = (signal: string) => {
-    console.log(`Received ${signal}. Starting graceful shutdown...`);
-
-    server.close(async () => {
-      console.log('Express server closed.');
-
-      try {
-        stopMetrics();
-        await closeDatabase();
-        console.log('Graceful shutdown completed.');
-        process.exit(0);
-      } catch (err) {
-        console.error('Error during shutdown:', err);
-        process.exit(1);
-      }
-    });
-  };
-
-  process.on('SIGINT', () => gracefulShutdown('SIGINT'));
-  process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));
+  startDiscord().catch(fatal);
+  startReplay();
+  if (SERVICE_EVENTS) startEvents();
 }
 
-start().catch(async err => {
-  console.error('Failed to start', err);
-  capture(err);
-  await Sentry.close(2000);
-  process.exit(1);
-});
+start().catch(fatal);

--- a/src/providers/discord.ts
+++ b/src/providers/discord.ts
@@ -33,6 +33,16 @@ const sweeperOption = { interval: 300, filter: () => null };
 // const invite = 'https://discord.com/oauth2/authorize?client_id=892847850780762122&permissions=534723951680&scope=bot';
 
 let subs = {};
+let stopping = false;
+const activeTasks = new Set<Promise<unknown>>();
+
+function track(task: () => Promise<unknown>) {
+  if (stopping) return;
+
+  const running = Promise.resolve().then(task).catch(capture);
+  activeTasks.add(running);
+  void running.finally(() => activeTasks.delete(running));
+}
 
 const client: any = new Client({
   intents: [
@@ -152,7 +162,9 @@ const PROPOSAL_EVENTS = [
   }
 ];
 
-(async () => {
+export async function start() {
+  stopping = false;
+
   try {
     console.log('[discord] started refreshing application (/) commands.');
     await rest.put(Routes.applicationCommands(CLIENT_ID), { body: commands });
@@ -160,9 +172,16 @@ const PROPOSAL_EVENTS = [
   } catch (err) {
     capture(err);
   }
-})();
 
-client.login(token);
+  await client.login(token);
+}
+
+export async function stop() {
+  stopping = true;
+  await Promise.allSettled(activeTasks);
+  await client.destroy();
+  console.log('[discord] client destroyed.');
+}
 
 export const setActivity = (message, url?) => {
   try {
@@ -208,12 +227,14 @@ const checkPermissions = async (channelId, botId) => {
   }
 };
 
-client.on('ready', async () => {
-  console.log(`[discord] bot logged as "${client.user.tag}"`);
-  setActivity('!');
+client.on('ready', () =>
+  track(async () => {
+    console.log(`[discord] bot logged as "${client.user.tag}"`);
+    setActivity('!');
 
-  await loadSubscriptions();
-});
+    await loadSubscriptions();
+  })
+);
 
 async function getEventsConfigured(
   guildId: string
@@ -265,34 +286,36 @@ async function snapshotSelectEventsCommandHandler(interaction) {
     time: 3_600_000
   });
 
-  collector.on('collect', async i => {
-    const selection = i.values;
-    try {
-      const result = await db
-        .update(subscriptions)
-        .set({ events: selection })
-        .where(eq(subscriptions.guild, i.guildId));
-      if (result.rowCount === 0) {
-        return i.update({
-          content: `No subscriptions found on this server. Please add a subscription first.`,
+  collector.on('collect', i =>
+    track(async () => {
+      const selection = i.values;
+      try {
+        const result = await db
+          .update(subscriptions)
+          .set({ events: selection })
+          .where(eq(subscriptions.guild, i.guildId));
+        if (result.rowCount === 0) {
+          return i.update({
+            content: `No subscriptions found on this server. Please add a subscription first.`,
+            components: [],
+            ephemeral: true
+          });
+        }
+        await loadSubscriptions();
+      } catch (err) {
+        capture(err);
+      }
+      await i
+        .update({
+          content: `Success! You will be notified for events ${selection
+            .map(a => `\`${a}\``)
+            .join(', ')}`,
           components: [],
           ephemeral: true
-        });
-      }
-      await loadSubscriptions();
-    } catch (err) {
-      capture(err);
-    }
-    await i
-      .update({
-        content: `Success! You will be notified for events ${selection
-          .map(a => `\`${a}\``)
-          .join(', ')}`,
-        components: [],
-        ephemeral: true
-      })
-      .catch(capture);
-  });
+        })
+        .catch(capture);
+    })
+  );
 }
 
 async function snapshotHelpCommandHandler(interaction) {
@@ -462,7 +485,7 @@ async function snapshotCommandHandler(interaction, commandType) {
   }
 }
 
-client.on('interactionCreate', async interaction => {
+async function handleInteraction(interaction) {
   if (!interaction.isChatInputCommand()) return;
 
   if (interaction.commandName === 'ping') {
@@ -471,15 +494,19 @@ client.on('interactionCreate', async interaction => {
       ephemeral: true
     });
   } else if (interaction.commandName === 'help') {
-    snapshotHelpCommandHandler(interaction);
+    await snapshotHelpCommandHandler(interaction);
   } else if (interaction.commandName === 'add') {
-    snapshotCommandHandler(interaction, 'add');
+    await snapshotCommandHandler(interaction, 'add');
   } else if (interaction.commandName === 'remove') {
-    snapshotCommandHandler(interaction, 'remove');
+    await snapshotCommandHandler(interaction, 'remove');
   } else if (interaction.commandName === 'select-events') {
-    snapshotSelectEventsCommandHandler(interaction);
+    await snapshotSelectEventsCommandHandler(interaction);
   }
-});
+}
+
+client.on('interactionCreate', interaction =>
+  track(() => handleInteraction(interaction))
+);
 
 export const sendMessage = async (channel, message) => {
   const end = timeOutgoingRequest.startTimer({ provider: 'discord' });
@@ -503,16 +530,19 @@ export const sendMessage = async (channel, message) => {
   }
 };
 
-const sendToSubscribers = (event, proposal, embed, components) => {
+const sendToSubscribers = async (event, proposal, embed, components) => {
   if (subs[proposal.space.id] || subs['*']) {
-    [...(subs['*'] || []), ...(subs[proposal.space.id] || [])].forEach(sub => {
-      if (sub.events && !sub.events.includes(event)) return;
-      sendMessage(sub.channel, {
-        content: `${sub.mention}`,
-        embeds: [embed],
-        components
-      });
-    });
+    await Promise.allSettled(
+      [...(subs['*'] || []), ...(subs[proposal.space.id] || [])]
+        .filter(sub => !sub.events || sub.events.includes(event))
+        .map(sub =>
+          sendMessage(sub.channel, {
+            content: `${sub.mention}`,
+            embeds: [embed],
+            components
+          })
+        )
+    );
   }
 };
 
@@ -540,7 +570,7 @@ export async function send(eventObj, proposal, _subscribers) {
           { name: 'Status', value: status, inline: true }
         )
         .addFields();
-      sendToSubscribers(event, proposal, embed, []);
+      await sendToSubscribers(event, proposal, embed, []);
       return { success: true };
     }
 
@@ -585,7 +615,7 @@ export async function send(eventObj, proposal, _subscribers) {
       )
       .setDescription(preview || ' ');
 
-    sendToSubscribers(event, proposal, embed, components);
+    await sendToSubscribers(event, proposal, embed, components);
 
     return { success: true };
   } catch (err: any) {

--- a/src/providers/webhook.ts
+++ b/src/providers/webhook.ts
@@ -62,7 +62,7 @@ export async function send(event, _proposal, _subscribersAddresses) {
     activeSubscribers.length
   );
 
-  Promise.allSettled(
+  await Promise.allSettled(
     activeSubscribers.map(subscriber =>
       sendEvent(event, subscriber.url, subscriber.method)
     )

--- a/src/replay.ts
+++ b/src/replay.ts
@@ -5,6 +5,11 @@ import { getLastMci, updateLastMci } from './db';
 import { handleCreatedEvent, handleDeletedEvent } from './events';
 
 const hubURL = process.env.HUB_URL || 'https://hub.snapshot.org';
+const INTERVAL = 10e3;
+
+let timer: NodeJS.Timeout | undefined;
+let running: Promise<void> | undefined;
+let stopped = false;
 
 export let last_mci = 0;
 
@@ -45,6 +50,8 @@ async function getNextMessages(mci: number) {
 async function processMessages(messages: any[]) {
   let lastMessageMci = null;
   for (const message of messages) {
+    if (stopped) break;
+
     try {
       if (message.type === 'proposal') {
         console.log('New event: "proposal"', message.space, message.id);
@@ -75,25 +82,41 @@ async function processMessages(messages: any[]) {
   return;
 }
 
-export async function run() {
-  while (true) {
-    try {
-      // Check latest indexed MCI from db
-      last_mci = await getLastMci();
-      console.log('[replay] Last MCI', last_mci);
+async function cycle() {
+  try {
+    // Check latest indexed MCI from db
+    last_mci = await getLastMci();
+    console.log('[replay] Last MCI', last_mci);
 
-      // Load next messages after latest indexed MCI
-      const messages = await getNextMessages(last_mci);
-      if (messages && messages.length > 0) {
-        await processMessages(messages);
-      }
-      await snapshot.utils.sleep(10e3);
-    } catch (err) {
-      console.error(err);
-      capture(err);
-      await Sentry.close(2000);
-      // CRASH THE ENTIRE SERVER
-      process.exit(1);
+    // Load next messages after latest indexed MCI
+    const messages = await getNextMessages(last_mci);
+    if (messages && messages.length > 0) {
+      await processMessages(messages);
     }
+  } catch (err) {
+    console.error(err);
+    capture(err);
+    await Sentry.close(2000);
+    // CRASH THE ENTIRE SERVER
+    process.exit(1);
   }
+}
+
+async function run() {
+  running = cycle();
+  await running;
+
+  if (!stopped) timer = setTimeout(run, INTERVAL);
+}
+
+export function start() {
+  stopped = false;
+  run();
+}
+
+export async function stop() {
+  stopped = true;
+  clearTimeout(timer);
+  await running;
+  console.log('[replay] Loop stopped');
 }

--- a/test/unit/events.shutdown.test.ts
+++ b/test/unit/events.shutdown.test.ts
@@ -1,0 +1,78 @@
+jest.mock('@snapshot-labs/snapshot-sentry', () => ({ capture: jest.fn() }));
+jest.mock('@snapshot-labs/snapshot.js', () => ({
+  __esModule: true,
+  default: { utils: { ipfsGet: jest.fn() } }
+}));
+jest.mock('../../src/db', () => {
+  const findMany = jest.fn();
+  const deleteWhere = jest.fn();
+  return {
+    __esModule: true,
+    findMany,
+    deleteWhere,
+    db: {
+      query: { events: { findMany } },
+      delete: () => ({ where: deleteWhere })
+    }
+  };
+});
+jest.mock('../../src/helpers/utils', () => ({
+  getProposal: jest.fn(),
+  getSubscribers: jest.fn().mockResolvedValue([])
+}));
+jest.mock('../../src/providers', () => ({
+  __esModule: true,
+  default: [jest.fn()]
+}));
+
+import * as dbModule from '../../src/db';
+import { start, stop } from '../../src/events';
+import { getSubscribers } from '../../src/helpers/utils';
+import providers from '../../src/providers';
+
+const { findMany, deleteWhere } = dbModule as unknown as {
+  findMany: jest.Mock;
+  deleteWhere: jest.Mock;
+};
+
+describe('events shutdown', () => {
+  it('does not start another event after stop', async () => {
+    let deliver: () => void = () => undefined;
+    const delivery = new Promise<void>(resolve => {
+      deliver = resolve;
+    });
+    const provider = providers[0] as jest.Mock;
+    provider
+      .mockImplementationOnce(() => delivery)
+      .mockResolvedValue(undefined);
+    jest.mocked(getSubscribers).mockResolvedValue([]);
+    findMany.mockResolvedValue([
+      { id: 'proposal/1', event: 'proposal/deleted', space: 's' },
+      { id: 'proposal/2', event: 'proposal/deleted', space: 's' }
+    ]);
+    deleteWhere.mockResolvedValue(undefined);
+    let scheduled = false;
+    const timeout = jest.spyOn(global, 'setTimeout').mockImplementation(((
+      callback: () => void
+    ) => {
+      if (!scheduled) {
+        scheduled = true;
+        queueMicrotask(callback);
+      }
+      return { unref: jest.fn() } as unknown as NodeJS.Timeout;
+    }) as typeof setTimeout);
+
+    start();
+    await new Promise(resolve => setImmediate(resolve));
+    expect(provider).toHaveBeenCalledTimes(1);
+    expect(deleteWhere).not.toHaveBeenCalled();
+
+    const stopped = stop();
+    deliver();
+    await stopped;
+
+    expect(provider).toHaveBeenCalledTimes(1);
+    expect(deleteWhere).toHaveBeenCalledTimes(1);
+    timeout.mockRestore();
+  });
+});

--- a/test/unit/helpers/metrics.shutdown.test.ts
+++ b/test/unit/helpers/metrics.shutdown.test.ts
@@ -1,0 +1,56 @@
+jest.mock('@snapshot-labs/snapshot-metrics', () => {
+  const gauges: any[] = [];
+  return {
+    __esModule: true,
+    default: jest.fn(() => ({ stop: jest.fn() })),
+    gauges,
+    client: {
+      Gauge: jest.fn(function (config) {
+        gauges.push(config);
+        return config;
+      }),
+      Histogram: jest.fn(function (config) {
+        return config;
+      })
+    }
+  };
+});
+jest.mock('@snapshot-labs/snapshot-sentry', () => ({ capture: jest.fn() }));
+jest.mock('../../../src/db', () => {
+  const $count = jest.fn();
+  return { __esModule: true, $count, db: { $count, $client: {} } };
+});
+
+import init from '@snapshot-labs/snapshot-metrics';
+import * as metricsPackage from '@snapshot-labs/snapshot-metrics';
+import * as dbModule from '../../../src/db';
+import initMetrics from '../../../src/helpers/metrics';
+
+const { $count } = dbModule as unknown as { $count: jest.Mock };
+
+describe('metrics shutdown', () => {
+  it('waits for an active database collection', async () => {
+    let resolveCount: (value: number) => void = () => undefined;
+    const counting = new Promise<number>(resolve => {
+      resolveCount = resolve;
+    });
+    $count.mockImplementationOnce(() => counting).mockResolvedValue(2);
+
+    const metrics = initMetrics({} as never);
+    const subscribersGauge = (metricsPackage as any).gauges[1];
+    const collection = subscribersGauge.collect.call({ set: jest.fn() });
+    let stopped = false;
+    const draining = metrics.stop().then(() => {
+      stopped = true;
+    });
+
+    await Promise.resolve();
+    expect(stopped).toBe(false);
+    expect(jest.mocked(init).mock.results[0].value.stop).toHaveBeenCalled();
+
+    resolveCount(1);
+    await collection;
+    await draining;
+    expect(stopped).toBe(true);
+  });
+});

--- a/test/unit/index.boot.test.ts
+++ b/test/unit/index.boot.test.ts
@@ -1,0 +1,96 @@
+jest.mock('@snapshot-labs/snapshot-sentry', () => ({
+  capture: jest.fn(),
+  fallbackLogger: jest.fn(),
+  initLogger: jest.fn(),
+  Sentry: { close: jest.fn().mockResolvedValue(true) }
+}));
+jest.mock('express', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
+    get: jest.fn(),
+    use: jest.fn(),
+    listen: jest.fn((_: unknown, callback: () => void) => {
+      callback();
+      return {
+        close: jest.fn((done: (err?: Error) => void) => done())
+      };
+    })
+  }))
+}));
+jest.mock('../../src/api', () => ({ __esModule: true, default: {} }));
+jest.mock('../../src/events', () => ({
+  start: jest.fn(),
+  stop: jest.fn().mockResolvedValue(undefined)
+}));
+jest.mock('../../src/helpers/metrics', () => ({
+  __esModule: true,
+  default: jest.fn()
+}));
+jest.mock('../../src/db', () => ({
+  closeDatabase: jest.fn().mockResolvedValue(undefined),
+  runMigrations: jest.fn()
+}));
+jest.mock('../../src/providers/discord', () => ({
+  start: jest.fn().mockResolvedValue(undefined),
+  stop: jest.fn().mockResolvedValue(undefined)
+}));
+jest.mock('../../src/replay', () => ({
+  last_mci: 0,
+  start: jest.fn(),
+  stop: jest.fn().mockResolvedValue(undefined)
+}));
+
+import { closeDatabase, runMigrations } from '../../src/db';
+import initMetrics from '../../src/helpers/metrics';
+import { start as startReplay } from '../../src/replay';
+
+describe('boot ordering', () => {
+  const inheritedListeners = new Set(process.listeners('SIGTERM'));
+  let consoleLog: jest.SpyInstance;
+  let exit: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleLog = jest.spyOn(console, 'log').mockImplementation();
+    exit = jest
+      .spyOn(process, 'exit')
+      .mockImplementation(() => undefined as never);
+  });
+
+  afterEach(() => {
+    for (const listener of process.listeners('SIGTERM')) {
+      if (!inheritedListeners.has(listener))
+        process.removeListener('SIGTERM', listener);
+    }
+    consoleLog.mockRestore();
+    exit.mockRestore();
+  });
+
+  it('handles a signal arriving while migrations are still running', async () => {
+    let migrated: () => void = () => undefined;
+    const migrating = new Promise<void>(resolve => {
+      migrated = resolve;
+    });
+    jest.mocked(initMetrics).mockReturnValue({
+      stop: jest.fn().mockResolvedValue(undefined)
+    });
+    jest.mocked(runMigrations).mockReturnValue(migrating);
+
+    await import('../../src/index');
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(runMigrations).toHaveBeenCalled();
+    expect(startReplay).not.toHaveBeenCalled();
+    expect(
+      process.listeners('SIGTERM').some(l => !inheritedListeners.has(l))
+    ).toBe(true);
+
+    process.emit('SIGTERM');
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(closeDatabase).toHaveBeenCalled();
+    expect(exit).toHaveBeenCalledWith(0);
+
+    migrated();
+    await new Promise(resolve => setImmediate(resolve));
+  });
+});

--- a/test/unit/index.shutdown.test.ts
+++ b/test/unit/index.shutdown.test.ts
@@ -1,0 +1,87 @@
+jest.mock('@snapshot-labs/snapshot-sentry', () => ({
+  capture: jest.fn(),
+  fallbackLogger: jest.fn(),
+  initLogger: jest.fn(),
+  Sentry: { close: jest.fn().mockResolvedValue(true) }
+}));
+jest.mock('express', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
+    get: jest.fn(),
+    use: jest.fn(),
+    listen: jest.fn((_: unknown, callback: () => void) => {
+      callback();
+      return {
+        close: jest.fn((done: (err?: Error) => void) => done())
+      };
+    })
+  }))
+}));
+jest.mock('../../src/api', () => ({ __esModule: true, default: {} }));
+jest.mock('../../src/events', () => ({
+  start: jest.fn(),
+  stop: jest.fn().mockResolvedValue(undefined)
+}));
+jest.mock('../../src/helpers/metrics', () => ({
+  __esModule: true,
+  default: jest.fn()
+}));
+jest.mock('../../src/db', () => ({
+  closeDatabase: jest.fn().mockResolvedValue(undefined),
+  runMigrations: jest.fn()
+}));
+jest.mock('../../src/providers/discord', () => ({
+  start: jest.fn().mockResolvedValue(undefined),
+  stop: jest.fn().mockResolvedValue(undefined)
+}));
+jest.mock('../../src/replay', () => ({
+  last_mci: 0,
+  start: jest.fn(),
+  stop: jest.fn().mockResolvedValue(undefined)
+}));
+
+import { closeDatabase, runMigrations } from '../../src/db';
+import initMetrics from '../../src/helpers/metrics';
+
+describe('shutdown ordering', () => {
+  const inheritedListeners = new Set(process.listeners('SIGTERM'));
+  let consoleLog: jest.SpyInstance;
+  let exit: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleLog = jest.spyOn(console, 'log').mockImplementation();
+    exit = jest
+      .spyOn(process, 'exit')
+      .mockImplementation(() => undefined as never);
+  });
+
+  afterEach(() => {
+    for (const listener of process.listeners('SIGTERM')) {
+      if (!inheritedListeners.has(listener))
+        process.removeListener('SIGTERM', listener);
+    }
+    consoleLog.mockRestore();
+    exit.mockRestore();
+  });
+
+  it('does not close the database before metrics drain', async () => {
+    let drain: () => void = () => undefined;
+    const draining = new Promise<void>(resolve => {
+      drain = resolve;
+    });
+    jest.mocked(initMetrics).mockReturnValue({ stop: jest.fn(() => draining) });
+    jest.mocked(runMigrations).mockResolvedValue(undefined);
+
+    await import('../../src/index');
+    await new Promise(resolve => setImmediate(resolve));
+    process.emit('SIGTERM');
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(closeDatabase).not.toHaveBeenCalled();
+    drain();
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(closeDatabase).toHaveBeenCalled();
+    expect(exit).toHaveBeenCalledWith(0);
+  });
+});

--- a/test/unit/providers/discord.shutdown.test.ts
+++ b/test/unit/providers/discord.shutdown.test.ts
@@ -1,0 +1,158 @@
+jest.mock('@snapshot-labs/snapshot-sentry', () => ({ capture: jest.fn() }));
+jest.mock('discord.js', () => {
+  const handlers: Record<string, (...args: any[]) => void> = {};
+  const client = {
+    channels: { cache: new Map(), fetch: jest.fn() },
+    destroy: jest.fn(),
+    login: jest.fn().mockResolvedValue(undefined),
+    on: jest.fn((event: string, handler: (...args: any[]) => void) => {
+      handlers[event] = handler;
+    }),
+    user: { setActivity: jest.fn(), tag: 'bot' },
+    ws: { ping: 1 }
+  };
+  const makeBuilder = () => {
+    const builder: any = new Proxy(
+      {},
+      {
+        get: (_, key) => {
+          if (key === 'then') return undefined;
+          return (...args: any[]) => {
+            for (const arg of args) {
+              if (typeof arg === 'function') arg(makeBuilder());
+            }
+            return builder;
+          };
+        }
+      }
+    );
+    return builder;
+  };
+  const Builder = jest.fn(function () {
+    return makeBuilder();
+  });
+  return {
+    __esModule: true,
+    handlers,
+    client,
+    Client: jest.fn(function () {
+      return client;
+    }),
+    REST: Builder,
+    SlashCommandBuilder: Builder,
+    ActionRowBuilder: Builder,
+    ButtonBuilder: Builder,
+    EmbedBuilder: Builder,
+    StringSelectMenuBuilder: Builder,
+    StringSelectMenuOptionBuilder: Builder,
+    ButtonStyle: { Link: 1 },
+    ComponentType: { StringSelect: 1 },
+    DiscordAPIError: class extends Error {},
+    GatewayIntentBits: {
+      Guilds: 1,
+      GuildMessages: 2,
+      DirectMessages: 3
+    },
+    Options: { cacheWithLimits: jest.fn(() => ({})) },
+    PermissionsBitField: { Flags: { ViewChannel: 1, SendMessages: 2 } },
+    Routes: { applicationCommands: jest.fn(() => 'commands') },
+    codeBlock: (value: string) => value,
+    inlineCode: (value: string) => value,
+    underscore: (value: string) => value
+  };
+});
+jest.mock('remove-markdown', () => ({
+  __esModule: true,
+  default: (value: string) => value
+}));
+jest.mock('../../../src/helpers/metrics', () => ({
+  outgoingMessages: { inc: jest.fn() },
+  timeOutgoingRequest: { startTimer: jest.fn(() => jest.fn()) }
+}));
+jest.mock('../../../src/db', () => {
+  const deleteWhere = jest.fn();
+  const findMany = jest.fn();
+  return {
+    __esModule: true,
+    deleteWhere,
+    findMany,
+    db: {
+      delete: () => ({ where: deleteWhere }),
+      query: { subscriptions: { findMany } }
+    }
+  };
+});
+jest.mock('../../../src/helpers/utils', () => ({
+  getSpace: jest.fn(),
+  shortenAddress: jest.fn()
+}));
+
+import * as discordJs from 'discord.js';
+import * as dbModule from '../../../src/db';
+import { stop } from '../../../src/providers/discord';
+
+const { deleteWhere, findMany } = dbModule as unknown as {
+  deleteWhere: jest.Mock;
+  findMany: jest.Mock;
+};
+
+const loginCallsAtImport = (discordJs as any).client.login.mock.calls.length;
+
+describe('Discord shutdown', () => {
+  it('does not log in at module import', () => {
+    expect(loginCallsAtImport).toBe(0);
+  });
+
+  it('waits for an active interaction before destroying the client', async () => {
+    let remove: (value: unknown) => void = () => undefined;
+    const removing = new Promise<unknown>(resolve => {
+      remove = resolve;
+    });
+    deleteWhere.mockImplementationOnce(() => removing);
+    findMany.mockResolvedValue([]);
+    const interaction = {
+      commandName: 'remove',
+      guildId: 'guild',
+      isChatInputCommand: () => true,
+      options: {
+        getChannel: () => ({ id: 'channel' }),
+        getString: (name: string) => (name === 'space' ? 'space' : null)
+      },
+      reply: jest.fn().mockResolvedValue(undefined),
+      user: { username: 'user' }
+    };
+    const discord = discordJs as any;
+    let destroy: () => void = () => undefined;
+    const destroying = new Promise<void>(resolve => {
+      destroy = resolve;
+    });
+    discord.client.destroy.mockReturnValue(destroying);
+
+    discord.handlers.interactionCreate(interaction);
+    await new Promise(resolve => setImmediate(resolve));
+
+    let stopped = false;
+    const draining = stop().then(() => {
+      stopped = true;
+    });
+    await Promise.resolve();
+    expect(stopped).toBe(false);
+    expect(discord.client.destroy).not.toHaveBeenCalled();
+
+    remove(undefined);
+    await new Promise(resolve => setImmediate(resolve));
+    expect(stopped).toBe(false);
+    expect(deleteWhere).toHaveBeenCalledTimes(1);
+    expect(findMany).toHaveBeenCalledTimes(1);
+
+    destroy();
+    await draining;
+
+    expect(interaction.reply).toHaveBeenCalled();
+    expect(discord.client.destroy).toHaveBeenCalled();
+
+    discord.handlers.interactionCreate(interaction);
+    await new Promise(resolve => setImmediate(resolve));
+    expect(deleteWhere).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/unit/replay.shutdown.test.ts
+++ b/test/unit/replay.shutdown.test.ts
@@ -1,0 +1,64 @@
+jest.mock('@snapshot-labs/snapshot-sentry', () => ({
+  capture: jest.fn(),
+  Sentry: { close: jest.fn().mockResolvedValue(true) }
+}));
+jest.mock('@snapshot-labs/snapshot.js', () => ({
+  __esModule: true,
+  default: { utils: { subgraphRequest: jest.fn() } }
+}));
+jest.mock('../../src/events', () => ({
+  handleCreatedEvent: jest.fn(),
+  handleDeletedEvent: jest.fn()
+}));
+jest.mock('../../src/db', () => ({
+  getLastMci: jest.fn().mockResolvedValue(0),
+  updateLastMci: jest.fn().mockResolvedValue(undefined)
+}));
+
+import snapshot from '@snapshot-labs/snapshot.js';
+import { getLastMci, updateLastMci } from '../../src/db';
+import { handleCreatedEvent } from '../../src/events';
+import { start, stop } from '../../src/replay';
+
+describe('replay shutdown', () => {
+  it('does not start another message after stop', async () => {
+    let index: () => void = () => undefined;
+    const indexing = new Promise<void>(resolve => {
+      index = resolve;
+    });
+    jest
+      .mocked(handleCreatedEvent)
+      .mockImplementationOnce(() => indexing as any)
+      .mockResolvedValue(undefined);
+    jest.mocked(getLastMci).mockResolvedValue(0);
+    jest.mocked(updateLastMci).mockResolvedValue(undefined);
+    jest.mocked(snapshot.utils.subgraphRequest).mockResolvedValue({
+      messages: [
+        { id: '1', mci: 1, type: 'proposal', space: 's' },
+        { id: '2', mci: 2, type: 'proposal', space: 's' }
+      ]
+    });
+    let scheduled = false;
+    const timeout = jest.spyOn(global, 'setTimeout').mockImplementation(((
+      callback: () => void
+    ) => {
+      if (!scheduled) {
+        scheduled = true;
+        queueMicrotask(callback);
+      }
+      return { unref: jest.fn() } as unknown as NodeJS.Timeout;
+    }) as typeof setTimeout);
+
+    start();
+    await new Promise(resolve => setImmediate(resolve));
+    expect(handleCreatedEvent).toHaveBeenCalledTimes(1);
+
+    const stopped = stop();
+    index();
+    await stopped;
+
+    expect(handleCreatedEvent).toHaveBeenCalledTimes(1);
+    expect(updateLastMci).toHaveBeenCalledWith(1);
+    timeout.mockRestore();
+  });
+});


### PR DESCRIPTION
The replay loop, the events loop and the Discord client all start implicitly and can never be stopped: replay is fired and forgotten, events arms a `setTimeout` into a `while (true)`, and the client logs in at module import, before any signal handler exists. `gracefulShutdown` closes only the HTTP server, metrics and the pool, so the workers keep running through the drain and the pool is ended underneath them, which turns a graceful exit into `process.exit(1)` from replay's catch.

Each worker now exposes `start()` / `stop()`. The two polling loops abort a pending interval immediately rather than waiting out the 10s/15s tick, still await the in-flight iteration, and check the abort flag between individual units of work, so a batch is truncated at a boundary rather than cut mid-write. Untouched rows stay in `events` and behind `last_mci` and are picked up on the next boot, which is what those tables are for.

`gracefulShutdown` drains the workers alongside the HTTP drain and closes the pool only once both are done. Signal handlers are registered before `runMigrations()` rather than after it, and Discord's login moves out of module import into `start()` after migrations, so a signal during migrations is handled and the `ready` handler can no longer query a table that does not exist yet.

Three smaller things on the same path:

- The metrics push timer survived SIGTERM: `init()` returns a `{ stop }` that was being dropped, and every interval collects gauges that query the pool the shutdown is about to close. It is now stopped, and `stop()` waits for a collection that is already in flight.
- `processEvents` fired providers in a non-awaited `forEach` and deleted the events row before any send completed, so a SIGTERM mid-send lost the notification permanently. The Discord and webhook providers had the same fire-and-forget shape internally, so all three layers now `await Promise.allSettled`, which keeps the existing tolerance for one provider failing without skipping the rest.
- A shutdown that cannot finish now force-exits instead of hanging until SIGKILL, and both that timeout and a failed shutdown reach Sentry rather than only the console.

Closes #293.
