### PR TITLE
fix(webhook): stop parseInt-truncating SERVICE_EVENTS_SALT

### DIFF
--- a/src/providers/webhook.ts
+++ b/src/providers/webhook.ts
@@ -7,12 +7,12 @@ import { sha256 } from '../helpers/utils';
 import { subscribers } from '../schema';
 
 const HTTP_WEBHOOK_TIMEOUT = 15000;
-const serviceEventsSalt = parseInt(process.env.SERVICE_EVENTS_SALT || '12345');
+const serviceEventsSalt = process.env.SERVICE_EVENTS_SALT || '12345';
 
 export async function sendEvent(event, to, method = 'POST') {
-  event.token = sha256(`${to}${serviceEventsSalt}`);
-  event.secret = sha256(`${to}${serviceEventsSalt}`);
-  const headerSecret = sha256(`${to}${process.env.SERVICE_EVENTS_SALT}`);
+  const secret = sha256(`${to}${serviceEventsSalt}`);
+  event.token = secret;
+  event.secret = secret;
   const url = to.replace('[PROPOSAL-ID]', event.id.split('/')[1]);
   const end = timeOutgoingRequest.startTimer({ method, provider: 'http' });
   let res;
@@ -22,7 +22,7 @@ export async function sendEvent(event, to, method = 'POST') {
       method,
       headers: {
         'Content-Type': 'application/json',
-        Authentication: headerSecret
+        Authentication: secret
       },
       timeout: HTTP_WEBHOOK_TIMEOUT,
       ...(method === 'POST' ? { body: JSON.stringify(event) } : {})

--- a/test/integration/webhook.test.ts
+++ b/test/integration/webhook.test.ts
@@ -156,8 +156,6 @@ describe('sendEvent()', () => {
   ])(
     'sends a token and secret matching the Authentication header, for %s',
     async (_label, salt) => {
-      mockFetch.mockClear();
-      mockFetch.mockResolvedValue({ status: 200 });
       const sendEvent = await loadSendEvent(salt);
 
       const event: any = { id: 'proposal/0xabc' };

--- a/test/integration/webhook.test.ts
+++ b/test/integration/webhook.test.ts
@@ -1,6 +1,6 @@
 import { eq } from 'drizzle-orm';
 import { closeDatabase, db } from '../../src/db';
-import { send } from '../../src/providers/webhook';
+import { send, sendEvent as SendEvent } from '../../src/providers/webhook';
 import { subscribers } from '../../src/schema';
 
 const OWNER = 'webhook-integration-test';
@@ -127,4 +127,50 @@ describe('send()', () => {
       expect.objectContaining({ method: 'GET' })
     );
   });
+});
+
+describe('sendEvent()', () => {
+  const ORIGINAL_SALT = process.env.SERVICE_EVENTS_SALT;
+
+  afterEach(() => {
+    if (ORIGINAL_SALT === undefined) delete process.env.SERVICE_EVENTS_SALT;
+    else process.env.SERVICE_EVENTS_SALT = ORIGINAL_SALT;
+  });
+
+  async function loadSendEvent(
+    salt: string | undefined
+  ): Promise<typeof SendEvent> {
+    if (salt === undefined) delete process.env.SERVICE_EVENTS_SALT;
+    else process.env.SERVICE_EVENTS_SALT = salt;
+
+    let loaded: typeof SendEvent;
+    await jest.isolateModulesAsync(async () => {
+      loaded = (await import('../../src/providers/webhook')).sendEvent;
+    });
+    return loaded!;
+  }
+
+  it.each([
+    ['a set SERVICE_EVENTS_SALT', '12345not-purely-numeric'],
+    ['an unset SERVICE_EVENTS_SALT', undefined]
+  ])(
+    'sends a token and secret matching the Authentication header, for %s',
+    async (_label, salt) => {
+      mockFetch.mockClear();
+      mockFetch.mockResolvedValue({ status: 200 });
+      const sendEvent = await loadSendEvent(salt);
+
+      const event: any = { id: 'proposal/0xabc' };
+      await sendEvent(event, 'https://webhook-integration.test/unit');
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [, options] = mockFetch.mock.calls[0];
+      const headerSecret = options.headers.Authentication;
+
+      expect(typeof headerSecret).toBe('string');
+      expect(headerSecret).toHaveLength(64);
+      expect(event.token).toBe(headerSecret);
+      expect(event.secret).toBe(headerSecret);
+    }
+  );
 });


### PR DESCRIPTION
## The bug

`sendEvent` in `src/providers/webhook.ts` derives three values from `SERVICE_EVENTS_SALT`: the outgoing `event.token`, `event.secret`, and the `Authentication` header. The body fields went through `parseInt(process.env.SERVICE_EVENTS_SALT || '12345')` while the header hashed `process.env.SERVICE_EVENTS_SALT` raw.

Two consequences:

- `parseInt` on a non-purely-numeric salt stops at the first non-digit character (or returns `NaN` if the string starts with a letter), so the body fields could be derived from a truncated, more predictable value than intended. This has been the code shape since PR #90 (2023).
- Because the body used the parsed value and the header used the raw one, the two were only ever equal by coincidence (e.g. when the salt happens to be a pure integer string). With any other salt, or with the env var unset, the header hash and the body hash diverge; an unset env var makes the header hash the literal string `"undefined"`, which is very unlikely to be intentional.

## The fix

Compute the salt-derived secret once, as a plain string (`process.env.SERVICE_EVENTS_SALT || '12345'`, no `parseInt`), and use that single value for `event.token`, `event.secret`, and the `Authentication` header. This removes the truncation and makes body and header identical by construction rather than by the two independently reaching the same formula.

## Backward compatibility

- `event.token` and `event.secret` are not documented in snapshot-docs or sx-monorepo's docs mirror; only `{id, event, space, expire}` are documented there.
- No test in this repo's own suite previously asserted these two field values.
- An org-wide search for `SERVICE_EVENTS_SALT` and `event.secret` across snapshot-labs turned up no consumer or verifier of these fields outside this file.
- The `Authentication` header value is unchanged by this PR: it already used the raw, untruncated env var. What changes is `event.token`/`event.secret`, which now match what the header already sends, and the fallback behavior when the env var is unset (previously the header hashed the literal string `"undefined"`; now it uses the same `'12345'` fallback as the body).

Given the above, this is being shipped without a migration or grace period. Flagging explicitly so a reviewer can weigh in if there's a consumer we didn't find.

## Testing

Added `describe('sendEvent()')` in `test/integration/webhook.test.ts`, asserting `event.token`/`event.secret` are byte-identical to the `Authentication` header, for both a set (non-purely-numeric) salt and an unset one. Mutation-proved: reverting to the old `parseInt` logic makes both new test cases fail; the fix makes them pass.